### PR TITLE
fix: Remove --only-missing flag from search-index rebuild

### DIFF
--- a/ckan/scripts/init_ckan.sh
+++ b/ckan/scripts/init_ckan.sh
@@ -43,7 +43,7 @@ paster --plugin=ckanext-ytp_recommendation recommendation init -c ${APP_DIR}/pro
 
 # refresh solr search indexes
 echo "rebuild solr search indexes ..."
-paster --plugin=ckan search-index rebuild -o -c ${APP_DIR}/production.ini
+paster --plugin=ckan search-index rebuild -c ${APP_DIR}/production.ini
 
 # set init flag to done
 echo "$CKAN_IMAGE_TAG" > ${DATA_DIR}/.init-done


### PR DESCRIPTION
This flag was left in the command accidentally. It causes the search index to not be cleared before rebuild.