### PR TITLE
fix(spatial search expanded map bug)

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/public/css/spatial_query.css
+++ b/modules/ckanext-ytp_main/ckanext/ytp/public/css/spatial_query.css
@@ -12,14 +12,12 @@
 }
 
 .dataset-map-expanded #dataset-map {
-  position: static;
   width: 940px;
   height: 435px;
-  top: -384px;
-  left: -1px;
+  top: 3% !important;
+  z-index: 1000;
   background-color: white;
   border: 1px solid #CCC;
-  margin: 0;
 }
 
 .dataset-map-expanded #dataset-map #dataset-map-attribution div {


### PR DESCRIPTION
The map becomes hidden under the other content on the page
when trying to expand the map. Fix this issue by giving the
map container a larger z index, modifying the top attribute and
removing the position attribute.