### PR TITLE
fix: disable ckanext-reminder snippets in dataset views

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/follow.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/follow.html
@@ -1,3 +1,4 @@
+{# FIXME: Pending ckanext-reminder CKAN 2.9 migration
 {% block follow_button %}
     {% if not hide_follow_button %}
         <div class="follow_button">
@@ -10,5 +11,6 @@
         </div>
     {% endif %}
 {% endblock %}
+#}
 {% block nums %}
 {% endblock %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/info.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/info.html
@@ -25,6 +25,7 @@ Example:
                 </dl>
               </div>
             {% endblock %}
+            {# FIXME: Pending ckanext-reminder CKAN 2.9 migration
             {% block follow_button %}
               {% if not hide_follow_button %}
                 <div class="follow_button">
@@ -37,6 +38,7 @@ Example:
                 </div>
               {% endif %}
             {% endblock %}
+            #}
           {% endblock %}
         </div>
       </div>


### PR DESCRIPTION
- ckanext-reminder is not fully migrated to CKAN 2.9, so the snippets cause errors