### PR TITLE
fix(AV-1668): Fix publisher list filters

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -629,6 +629,10 @@ def get_organization_filters_count():
                                 'include_groups': False,
                                 'include_tags  ': False,
                                 'include_tags  ': False})
-    with_dataset_count = len(list(filter(lambda x: (x["package_count"] > 0), organizations["page_results"])))
-    all_count = len(organizations["page_results"])
+
+    organizations_with_datasets = get_action('organization_tree_list')({}, {'with_datasets': True})
+
+    with_dataset_count = len(organizations_with_datasets['global_results'])
+    all_count = len(organizations['global_results'])
+
     return {'with_dataset_count': with_dataset_count, 'all_count': all_count}


### PR DESCRIPTION
Modify the queries that are fetching the amount of organizations and
organizations with datasets. These queries are displayed in the filtering options
in the publishers page. Instead of displaying only the amount of orgs shown on current page,
show the total amount available in the filter texts.

Refs AV-1668