### PR TITLE
Fixes to 2.9 migration

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/resource_edit_base.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/resource_edit_base.html
@@ -2,7 +2,7 @@
 {% block content_primary_nav %}
   {{ h.build_nav_icon(pkg.type ~ '_resource.edit', _('Edit resource'), id=pkg.name, resource_id=res.id) }}
   {% if 'datapusher' in g.plugins %}
-    {{ h.build_nav_icon('datastore.dictionary', _('DataStore'), id=pkg.name, resource_id=res.id) }}
+    {{ h.build_nav_icon('datapusher.resource_data', _('DataStore'), id=pkg.name, resource_id=res.id) }}
   {% endif %}
     {{ h.build_nav_icon(pkg.type ~ '_resource.views', _('Views'), id=pkg.name, resource_id=res.id) }}
 {% endblock %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/spatial/snippets/spatial_query.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/spatial/snippets/spatial_query.html
@@ -27,6 +27,7 @@ e.g.
 </section>
 
 {% asset 'ckanext-spatial/spatial_query_js' %}
+{% asset 'ckanext-spatial/spatial_query_css' %}
 {% asset 'ytp_resources/spatial_query_css' %}
 {% asset 'ckanext-spatial/dataset_map_js' %}
 {% asset 'ckanext-spatial/dataset_map_css' %}


### PR DESCRIPTION
- Fix DataStore link on resource edit page
- Reorganize ckanext-spatial assets to fix draw icon