### PR TITLE
feat(AV-1528) Resource page implementation

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/resource_read.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/resource_read.html
@@ -12,14 +12,42 @@
   <script type="text/javascript" src="https://www.google.com/jsapi"></script>
 {% endblock -%}
 
+
 {% block subtitle %}{{ h.dataset_display_name(c.package) }} - {{ h.resource_display_name(res) }}{% endblock %}
 
-{% block breadcrumb_content_selected %}
-{% endblock %}
+  {% block toolbar %}
+  <div class="toolbar">
+    {% block breadcrumb %}
+      {% if self.breadcrumb_content() | trim %}
+        <ol class="breadcrumb">
+          {% snippet 'snippets/home_breadcrumb_item.html' %}
+          {% block breadcrumb_content %}
+          {{ super() }}
+          <!-- Remove active from preceeding lists -->
+          <script>
+            var elements = document.querySelectorAll("breadcrumb");
+            [].forEach.call(elements, function(el){
+              el.classList.remove("active");
+            });
+          </script>
+          <li class="active"><a href="">{{ h.resource_display_name(res)| truncate(30) }}</a></li>
+          {% endblock %}
+        </ol>
+      {% endif %}
+    {% endblock %}
+    <div class="toolbar-secondary-wrapper">
+      <div class="row toolbar-resource-secondary">
+        <i class="fas fa-long-arrow-left"></i>
+        {% trans  url=h.url_for(pkg.type ~ '.read', id=c.package['name']) %}<a href="{{ url }}">{% endtrans %}{{_('dataset')}}</a>
+      </div>
+     
+    </div>
+      
+  </div>
+  {% endblock %}
 
-{% block breadcrumb_content %}
-  {{ super() }}
-  <li class="active"><a href="">{{ h.resource_display_name(res)| truncate(30) }}</a></li>
+{% block prelude %}
+
 {% endblock %}
 
 {% block primary_content %}
@@ -27,55 +55,51 @@
     <div class="container-module-resource">
       <section class="module module-resource">
         <div class="module-content">
-          <div>
-            <div class="actions">
-              {% block resource_actions %}
-                <ul>
-                  {% block resource_actions_inner %}
-                    {% if h.check_access('package_update', {'id':pkg.id }) %}
-                      <li>{% link_for _('Manage'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-menu-manage', icon='wrench' %}</li>
-                    {% endif %}
-                    {% if res.url %}
-                      <li>
-                        <a class="btn btn-menu-manage resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
-                          {% if res.resource_type in ('listing', 'service') %}
-                            <i class="fas fa-eye"></i> {{ _('View') }}
-                          {% elif  res.resource_type == 'api' %}
-                            <i class="fas fa-key"></i> {{ _('API Endpoint') }}
-                          {% elif not res.can_be_previewed and res.url_type != 'upload' %}
-                            <i class="fas fa-external-link-alt"></i> {{ _('Open') }}
-                          {% else %}
-                            <i class="fas fa-download"></i> {{ _('Download') }}
-                          {% endif %}
-                        </a>
-                      </li>
-                    {% endif %}
-                    {% if 'datastore' in g.plugins %}
-                      <li>{% snippet 'package/snippets/data_api_button.html', resource=res, datastore_root_url=c.datastore_api %}</li>
-                    {% endif %}
-                  {% endblock %}
-                </ul>
-              {% endblock %}
-            </div>
-            {% block resource_content %}
-              {% block resource_read_title %}
-                <h1 class="page-heading">{{ h.extra_translation(res, 'name', fallback=h.resource_display_name) }}</h1>
-              {% endblock %}
-              {% block resource_read_url %}
-                {%- for field in schema.resource_fields -%}
-                  {% if field.field_name == 'maturity' %}
-                    {% for choice in field.choices %}
-                      {% if choice.value == res.maturity %}
-                        <h4>{{ _('Maturity') }}: <span class="label label-primary">{{ _(choice.label) }}</span></h4>
+            <div class="row justify-content-between pb-2">
+              <div class="actions col-md-6 justify-content-end">
+                {% block resource_actions %}
+                  <ul>
+                    {% block resource_actions_inner %}
+                      {% if h.check_access('package_update', {'id':pkg.id }) %}
+                        <li>{% link_for _('Manage'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-menu-manage', icon='wrench' %}</li>
                       {% endif %}
-                    {% endfor %}
-                  {% endif %}
-                {% endfor %}
-                {% if res.url %}
-                  <p class="muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics resource-type-"{{ res.resource_type }} href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a></p>
-                {% endif %}
-              {% endblock %}
-              <div class="prose notes" property="rdfs:label">
+                      {% if res.url %}
+                        <li>
+                          <a class="btn btn-menu-manage resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+                            {% if res.resource_type in ('listing', 'service') %}
+                              <i class="fas fa-eye"></i> {{ _('View') }}
+                            {% elif  res.resource_type == 'api' %}
+                              <i class="fas fa-key"></i> {{ _('API Endpoint') }}
+                            {% elif not res.can_be_previewed and res.url_type != 'upload' %}
+                              <i class="fas fa-external-link-alt"></i> {{ _('Open') }}
+                            {% else %}
+                              <i class="fas fa-download"></i> {{ _('Download') }}
+                            {% endif %}
+                          </a>
+                        </li>
+                      {% endif %}
+                      {% if 'datastore' in g.plugins %}
+                        <li>{% snippet 'package/snippets/data_api_button.html', resource=res, datastore_root_url=c.datastore_api %}</li>
+                      {% endif %}
+                    {% endblock %}
+                  </ul>
+                {% endblock %}
+              </div>
+              <div class="col-md-4 order-first">
+                <p class="module-small-title">{% trans dataset=c.package.title %}{{ dataset }}{% endtrans %}</p>
+              </div>
+            </div>
+            
+            <div class="row justify-content-center pb-1">
+              {% block resource_content %}
+              <div class="col-md-12">
+                {% block resource_read_title %}
+                  <h1 class="page-heading">{{ h.extra_translation(res, 'name', fallback=h.resource_display_name) }}</h1>
+                {% endblock %}
+              </div>
+            </div>
+            <div class="row justify-content-center">
+              <div class="col-md-12 prose notes" property="rdfs:label">
                 {% set description = h.extra_translation(res, 'description', markdown=True) %}
                 {% if description %}
                   {{ description }}
@@ -89,156 +113,140 @@
                 {% endif %}
               </div>
             {% endblock %}
-          </div>
-          {% block data_preview %}
-            {% block resource_view %}
-              {% block resource_view_nav %}
-                {% set resource_preview = h.resource_preview(c.resource, c.package) %}
-                {% snippet "package/snippets/resource_views_list.html",
-                  views=resource_views,
-                  pkg=pkg,
-                  is_edit=false,
-                  view_id=current_resource_view['id'],
-                  resource_preview=resource_preview,
-                  resource=c.resource,
-                  extra_class="nav-tabs-plain"
-                %}
-              {% endblock %}
-                {% block resource_view_content %}
-                  <div class="resource-view">
-                    {% set resource_preview = h.resource_preview(c.resource, c.package) %}
-                    {% set views_created = res.has_views or resource_preview %}
-                    {% if views_created %}
-                      {% if resource_preview and not current_resource_view %}
-                        {{ h.resource_preview(c.resource, c.package) }}
-                      {% else %}
-                        {% for resource_view in resource_views %}
-                          {% if resource_view == current_resource_view %}
-                            {% snippet 'package/snippets/resource_view.html',
-                              resource_view=resource_view,
-                              resource=c.resource,
-                              package=c.package
-                            %}
-                          {% endif %}
-                        {% endfor %}
-                      {% endif %}
-                    {% else %}
-                      {# Views not created #}
-                      <div class="data-viewer-info">
-                        <p>{{ _("There are no views created for this resource yet.") }}</p>
-                        {% if h.check_access('resource_view_create', {'resource_id': c.resource.id}) %}
-                          <p class="text-muted">
-                            <i class="fa fa-info-circle"></i>
-                            {{ _("Not seeing the views you were expecting?")}}
-                            <a href="javascript:void(0);" data-toggle="collapse" data-target="#data-view-info">
-                              {{ _('Click here for more information.') }}</a>
-                          </p>
-                          <div id="data-view-info" class="collapse">
-                            <p>{{ _('Here are some reasons you may not be seeing expected views:') }}</p>
-                            <ul>
-                              <li>{{ _("No view has been created that is suitable for this resource")}}</li>
-                              <li>{{ _("The site administrators may not have enabled the relevant view plugins")}}</li>
-                              <li>{{ _("If a view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet")}}</li>
-                            </ul>
-                          </div>
-                        {% endif %}
-                      </div>
-                    {% endif %}
-                  </div>
+            </div>
+
+          <div class="row justify-content-center pb-3">
+            {% block data_preview %}
+              {% block resource_view %}
+                {% block resource_view_nav %}
+                  {% set resource_preview = h.resource_preview(c.resource, c.package) %}
+                  {% snippet "package/snippets/resource_views_list.html",
+                    views=resource_views,
+                    pkg=pkg,
+                    is_edit=false,
+                    view_id=current_resource_view['id'],
+                    resource_preview=resource_preview,
+                    resource=c.resource,
+                    extra_class="nav-tabs-plain"
+                  %}
                 {% endblock %}
+                  {% block resource_view_content %}
+                    <div class="resource-view col-md-12">
+                      <h3 class="mt-0">{{ _('Preview') }}</h3>
+                      {% set resource_preview = h.resource_preview(c.resource, c.package) %}
+                      {% set views_created = res.has_views or resource_preview %}
+                      {% if views_created %}
+                        {% if resource_preview and not current_resource_view %}
+                          {{ h.resource_preview(c.resource, c.package) }}
+                        {% else %}
+                          {% for resource_view in resource_views %}
+                            {% if resource_view == current_resource_view %}
+                              {% snippet 'package/snippets/resource_view.html',
+                                resource_view=resource_view,
+                                resource=c.resource,
+                                package=c.package
+                              %}
+                            {% endif %}
+                          {% endfor %}
+                        {% endif %}
+                      {% else %}
+                        {# Views not created #}
+                        <div class="data-viewer-info">
+                          <p>{{ _("There are no views created for this resource yet.") }}</p>
+                          {% if h.check_access('resource_view_create', {'resource_id': c.resource.id}) %}
+                            <p class="text-muted">
+                              <i class="fa fa-info-circle"></i>
+                              {{ _("Not seeing the views you were expecting?")}}
+                              <a href="javascript:void(0);" data-toggle="collapse" data-target="#data-view-info">
+                                {{ _('Click here for more information.') }}</a>
+                            </p>
+                            <div id="data-view-info" class="collapse">
+                              <p>{{ _('Here are some reasons you may not be seeing expected views:') }}</p>
+                              <ul>
+                                <li>{{ _("No view has been created that is suitable for this resource")}}</li>
+                                <li>{{ _("The site administrators may not have enabled the relevant view plugins")}}</li>
+                                <li>{{ _("If a view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet")}}</li>
+                              </ul>
+                            </div>
+                          {% endif %}
+                        </div>
+                      {% endif %}
+                    </div>
+                  {% endblock %}
+              {% endblock %}
             {% endblock %}
-          {% endblock %}
+          </div>
+          <div class="row justify-content-center pb-3">
+            {% block resource_additional_information %}
+              {% if res %}
+                  <div class="col-md-12">
+                    <div class="module-content ">
+                      <h3 class="mt-0">{{ _('Extra information') }}</h3>
+                        <div>
+                          <table class="resource-module-table">
+                            <tr>
+                              <th>{{ _('Format') }}</th>
+                              <th>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</th>
+                            {%- set exclude_fields = [
+                              'name_translated',
+                              'name',
+                              'description',
+                              'description_translated',
+                              'temporal_granularity',
+                              'temporal_coverage_from',
+                              'temporal_coverage_to',
+                              'update_frequency',
+                              'description_translated',
+                              'url',
+                              'format',
+                              'status_updated',
+                              'malware',
+                              'sha256',
+                              'url_type'
+                            ] -%}
+                            {%- for field in schema.resource_fields -%}
+                              {%- if field.field_name not in exclude_fields and field.display_snippet is not none
+                              and field.field_name in res and field[field.field_name] != "" -%}
+                                <tr>
+                                  <th>{{- h.scheming_language_text(field.label) -}} </th>
+                                  <th>{%- snippet 'scheming/snippets/display_field.html',
+                                    field=field, data=res, entity_type='dataset',
+                                    object_type=dataset_type -%}</th>
+                                </tr>
+                              {%- endif -%}
+                            {%- endfor -%}
+                          </tr>
+                          <tr>
+                            <th>{{ _('Temporal Coverage') }}</th>
+                            <th>{% if res.temporal_coverage_from %}{{ h.render_date(h.date_str_to_datetime(res.temporal_coverage_from)) }}{% endif %} -
+                              {% if res.temporal_coverage_to %}{{ h.render_date(h.date_str_to_datetime(res.temporal_coverage_to))}}{% endif %}
+                            </th>
+                          </tr>
+                          <tr>
+                            <th>{{ _('Last updated') }}</th>
+                            <th>{{ h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</th>
+                          </tr>
+                          <tr>
+                            <th>{{ _('Created') }}</th>
+                            <th>{{ h.render_datetime(res.created) or _('unknown') }}</th>
+                          </tr>
+                          <tr>
+                            <th>{{ _('sha256')|upper }}</th>
+                            <th>{{ h.get_resource_sha256(res.id) or _('unknown') }}</th>
+                          </tr>
+                          </table>
+                        </div>
+                    </div>
+                  </div>
+              </div>
+              {% endif %}
+            {% endblock %}
+          </div>
         </div>
       </section>
 
     {% endblock %}
-    {% block resource_additional_information %}
-      {% if res %}
-        <section class="module">
-          <div class="module-content">
-            <h2 class="mt-0">{{ _('Extra information') }}</h2>
-            <div class="p-3 mt-3 bg-depth-light30">
-              <dl class="dl-horizontal mt-3">
 
-                <dt>{{ _('Last updated') }}</dt>
-                <dd>{{ h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</dd>
-
-                <dt>{{ _('Created') }}</dt>
-                <dd>{{ h.render_datetime(res.created) or _('unknown') }}</dd>
-
-                <dt>{{ _('Format') }}</dt>
-                <dd>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</dd>
-
-                <dt>{{ _('License') }}</dt>
-                <dd>{% snippet "snippets/license.html", pkg_dict=pkg, text_only=True %}</dd>
-                {% if res.temporal_granularity %}
-                  <dt>{{ _('Temporal Granularity')}}</dt>
-                  <dd>{%- snippet 'scheming/snippets/display_field.html',
-                        field=h.get_field_from_resource_schema(schema, 'temporal_granularity'), data=res, entity_type='dataset',
-                        object_type=dataset_type -%}</dd>
-                {% endif %}
-
-                {% if res.update_frequency %}
-                  <dt>{{ _('Update Frequency') }}</dt>
-                  <dd>{{ h.extra_translation(res, 'update_frequency') }}</dd>
-                {% endif %}
-
-                {% if res.temporal_coverage_from or res.temporal_coverage_to %}
-                  <dt>{{ _('Temporal Coverage') }}</dt>
-                  <dd>
-                    {% if res.temporal_coverage_from %}{{ h.render_date(h.date_str_to_datetime(res.temporal_coverage_from)) }}{% endif %} -
-                    {% if res.temporal_coverage_to %}{{ h.render_date(h.date_str_to_datetime(res.temporal_coverage_to))}}{% endif %}
-                  </dd>
-                {% endif %}
-              </dl>
-            </div>
-
-            <h3>{{_('Technical extra information')}}</h3>
-            <div class="p-3 mt-3 bg-depth-light30">
-              {%- set exclude_fields = [
-                'name',
-                'description',
-                'description_translated',
-                'temporal_granularity',
-                'temporal_coverage_from',
-                'temporal_coverage_to',
-                'update_frequency',
-                'description_translated',
-                'url',
-                'format',
-                'status_updated',
-                'malware',
-                'sha256'
-              ] -%}
-              <div>
-                <dl class="dl-horizontal mt-2">
-                  {%- for field in schema.resource_fields -%}
-                    {%- if field.field_name not in exclude_fields and field.display_snippet is not none
-                    and field.field_name in res and field[field.field_name] != "" -%}
-                      <dt scope="row">
-                        {{- h.scheming_language_text(field.label) -}}
-                      </dt>
-                      <dd>
-                        {%- snippet 'scheming/snippets/display_field.html',
-                        field=field, data=res, entity_type='dataset',
-                        object_type=dataset_type -%}
-                      </dd>
-                    {%- endif -%}
-                  {%- endfor -%}
-                  <dt scope="row">
-                    SHA256
-                  </dt>
-                  <dd>
-                  {{ h.get_resource_sha256(res.id) }}
-                  </dd>
-                </dl>
-              </div>
-            </div>
-          </div>
-        </section>
-      </div>
-      {% endif %}
-    {% endblock %}
   {% endblock %}
 
 {% block secondary_content %}


### PR DESCRIPTION
Implemented the resource page according to [Abstract](https://app.abstract.com/projects/90f3001a-18bc-484a-bbba-a9ea120bcdcf/branches/master/commits/f8fdaca48243d1921dbcb501a4322f9d3b0e036b/files/05B60443-A1BA-4B89-A5CE-558E950075F5/layers/C1C29B6C-16CD-42CE-9143-40D6118754C4?mode=build&selected=2677685709-C571CC60-3358-4986-8054-7DA6785F9EDE&sha=f8fdaca48243d1921dbcb501a4322f9d3b0e036b). 

Some changes were omitted in order to match the general layout of the site (mainly the white background). Also the two buttons for opening the dataset were also omitted. Some existing elements such as the edit and download button were kept from the old design.
Refer to the image for the implemented version. 
![image](https://user-images.githubusercontent.com/24498487/171629648-f48b3e2b-07f6-49e3-8828-dacd6613abca.png)
