### PR TITLE
fix(AV-1675): Convert CC0-1.0 license_id in sixodp-harvester

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/harvesters/sixodp_harvester.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/harvesters/sixodp_harvester.py
@@ -31,6 +31,11 @@ DATETIME_FORMATS = [
 ]
 
 
+LICENSE_MAP = {
+    'cc0-1.0': 'cc-zero-1.0'
+}
+
+
 def parse_datetime(datetime_string):
     if not datetime_string:
         return None
@@ -137,6 +142,13 @@ def sixodp_to_opendata_postprocess(package_dict):
     package_dict['collection_type'] = 'Open Data'
     package_dict['maintainer'] = package_dict.get('maintainer', ' ') or ' '
     package_dict['maintainer_email'] = package_dict.get('maintainer_email', ' ') or ' '
+
+    # Map license IDs from sixodp to opendata format
+    license_id = package_dict.get('license_id')
+    if license_id:
+        package_dict['license_id'] = (LICENSE_MAP.get(license_id.lower())
+                                      or package_dict['license_id'])
+
     date_released = parse_datetime(package_dict['date_released'])
     if date_released:
         date_released_isoformat = "%s.000000" % date_released.isoformat().split('+', 2)[0]


### PR DESCRIPTION
- Convert `cc0-1.0` `license_id`s to `cc-zero-1.0` in an extendable way