### PR TITLE
fix(AV-1744): Removed sort by source from dataset and advanced search

### DIFF
--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/index.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/index.html
@@ -100,7 +100,6 @@
                       (_('Last Modified'), 'metadata_modified desc'),
                       (_('Date Created Ascending'), 'metadata_created asc'),
                       (_('Date Created Descending'), 'metadata_created desc'),
-                      (_('Source'), 'source asc'),
                       (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
                     %}
                     {% set sorting_selected = c.advanced_search.sort_string %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
@@ -59,7 +59,6 @@
             (_('Last Modified'), 'metadata_modified desc'),
             (_('Date Created Ascending'), 'metadata_created asc'),
             (_('Date Created Descending'), 'metadata_created desc'),
-            (_('Source'), 'source asc'),
             (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
           %}
           {% snippet 'snippets/search_form.html', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, query_params=c.fields_grouped, show_advanced_search=true %}


### PR DESCRIPTION
Removed the sort by source option from datasets and advanced search pages
![image](https://user-images.githubusercontent.com/24498487/173524794-2170daf4-f704-4e6d-a728-202448cc0ba8.png)
![image](https://user-images.githubusercontent.com/24498487/173525014-f60f2c97-6670-4443-8c07-0171325430e9.png)

