### PR TITLE
fix(AV-1701): Keep filters active while changing sorting

### DIFF
--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/search.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/search.html
@@ -40,7 +40,7 @@
       {{ h.snippet('sixodp_showcase/snippets/showcase_greeting.html') }}
       {% block form %}
         <div class="search-form-container search-form-container-borderless">
-          {{ h.snippet('sixodp_showcase/snippets/showcase_search_input.html', query=q, placeholder=_('Search applications...'), query_params=fields_grouped, sorting=sort_by_selected, page=page) }}
+          {{ h.snippet('sixodp_showcase/snippets/showcase_search_input.html', query=q, placeholder=_('Search applications...'), query_params=fields_grouped, sorting=sorting, sort_by_selected=sort_by_selected, page=page) }}
         </div>
       {% endblock %}
 

--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html
@@ -20,6 +20,6 @@
             (_('Top rating'), 'rating desc') ]
         %}
         <div class="search-options">
-            {% snippet 'sixodp_showcase/snippets/showcase_search_form.html', type='showcase', placeholder=_('Search showcases...'), query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, show_empty=request.params, error=query_error, fields=fields, no_bottom_border=true, show_advanced_search=false %}
+            {% snippet 'sixodp_showcase/snippets/showcase_search_form.html', type='showcase', placeholder=_('Search showcases...'), query=q, query_params=query_params, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, show_empty=request.params, error=query_error, fields=fields, no_bottom_border=true, show_advanced_search=false %}
         </div>
     {% endblock %}


### PR DESCRIPTION
Bypass query_params for showcases search_form so that they wont be dropped off when sorting is changed