### PR TITLE
fix(AV-1750): Removed sorting showcases by rating

### DIFF
--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html
@@ -16,8 +16,7 @@
             (_('Relevance'), 'score desc, metadata_modified desc'),
             (_('Name Ascending'), 'title_string asc'),
             (_('Name Descending'), 'title_string desc'),
-            (_('Last Modified'), 'metadata_modified desc'),
-            (_('Top rating'), 'rating desc') ]
+            (_('Last Modified'), 'metadata_modified desc')]
         %}
         <div class="search-options">
             {% snippet 'sixodp_showcase/snippets/showcase_search_form.html', type='showcase', placeholder=_('Search showcases...'), query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, show_empty=request.params, error=query_error, fields=fields, no_bottom_border=true, show_advanced_search=false %}


### PR DESCRIPTION
Removed sorting showcases by their rating
![image](https://user-images.githubusercontent.com/24498487/173554252-05f5e2f4-ee78-4dac-8fcb-168a24102459.png)
