### PR TITLE
feat(AV-762): Added SPARQL support

### DIFF
--- a/ckan/templates/production.ini.j2
+++ b/ckan/templates/production.ini.j2
@@ -171,6 +171,11 @@ ckanext.forcetranslation.domain = ckanext-ytp_main
 ckanext.dcat.rdf.profiles = avoindata_dcat_ap
 ckanext.dcat.translate_keys = False
 ckanext.dcat.base_uri = {{ environ('SITE_PROTOCOL') }}://{{ environ('DOMAIN_NAME') }}/data
+ckanext.dcat.sparql.profiles = avoindata_dcat_ap
+ckanext.dcat.sparql.query_endpoint = http://{{ environ('FUSEKI_HOST') }}:{{ environ('FUSEKI_PORT') }}/{{ environ('FUSEKI_OPENDATA_DATASET') }}
+ckanext.dcat.sparql.update_endpoint = http://{{ environ('FUSEKI_HOST') }}:{{ environ('FUSEKI_PORT') }}/{{ environ('FUSEKI_OPENDATA_DATASET') }}/update
+ckanext.dcat.sparql.username = {{ environ('FUSEKI_ADMIN_USER') }}
+ckanext.dcat.sparql.password = {{ environ('FUSEKI_ADMIN_PASS') }}
 
 ckanext.geoview.ol_viewer.formats = wms wfs geojson
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/dcat.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/dcat.py
@@ -310,7 +310,13 @@ class AvoindataDCATAPProfile(RDFProfile):
                 g.add((theme, SKOS.prefLabel, Literal(title)))
 
         # dcat:landingPage
-        external_urls = (u for u in dataset_dict.get('external_urls', []) if u)
+        external_urls = dataset_dict.get('external_urls', [])
+        if isinstance(external_urls, six.text_type):
+            try:
+                external_urls = json.loads(external_urls)
+            except json.JSONDecodeError:
+                external_urls = []
+        external_urls = (u for u in external_urls if u)
 
         for external_url in external_urls:
             # some external urls have whitespace in them

--- a/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -6,6 +6,7 @@ import urllib.error
 import urllib.parse
 import datetime
 import itertools
+import flask
 from ckan.common import _, c, request
 from ckan.lib import helpers, i18n
 from ckan.logic import get_action
@@ -40,7 +41,11 @@ def get_translation(translated):
         translated = get_json_value(translated)
 
     if isinstance(translated, dict):
-        language = i18n.get_lang()
+        if flask.has_request_context():
+            language = i18n.get_lang()
+        else:
+            language = ''
+
         if language in translated:
             return translated[language]
         dialects = [lang for lang in translated


### PR DESCRIPTION
- Updated `ckanext-dcat` to support SPARQL
- Added SPARQL server configuration to `production.ini`
- Added support for json-encoded lists of external URLs to Opendata DCAT profile
- Handled an edge case in translation where `get_translation` is called outside a request context