### PR TITLE
fix(AV-1174): default sorting

### DIFF
--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/controller.py
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/controller.py
@@ -72,8 +72,8 @@ def search():
                     search_query_filters.append(res)
 
     sort_string = request.form.get('sort', 'metadata_created desc')
-    #if an actual sort parameter is provided, use that for selection in the template
-    sorting_selection = request.form.get('sort') 
+    # if an actual sort parameter is provided, use that for selection in the template
+    sorting_selection = request.form.get('sort')
 
     data_dict = {
         'q': q,
@@ -125,7 +125,7 @@ def search():
         "filters": filters,
         "sort_string": sort_string,
         "field_options": options,
-        "sorting_selection": sorting_selection   
+        "sorting_selection": sorting_selection
         }
     c.advanced_search['last_query']['page'] = page
 

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/controller.py
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/controller.py
@@ -72,6 +72,8 @@ def search():
                     search_query_filters.append(res)
 
     sort_string = request.form.get('sort', 'metadata_created desc')
+    #if an actual sort parameter is provided, use that for selection in the template
+    sorting_selection = request.form.get('sort') 
 
     data_dict = {
         'q': q,
@@ -80,7 +82,7 @@ def search():
         'extras': {},
         'sort': sort_string,
         'defType': 'edismax',
-        'mm': 0
+        'mm': 0,
     }
 
     if search_query_filters:
@@ -122,7 +124,8 @@ def search():
         "json_query": json_query,
         "filters": filters,
         "sort_string": sort_string,
-        "field_options": options
+        "field_options": options,
+        "sorting_selection": sorting_selection   
         }
     c.advanced_search['last_query']['page'] = page
 

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/index.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/index.html
@@ -94,6 +94,7 @@
                       {% snippet 'advanced_search/display_field.html', field=schema.input_fields.search_query, prev_query=c.advanced_search.last_query %}
                     </div>
                     {% set sorting = [
+                      ('', 'auto'),
                       (_('Relevance'), 'score desc, metadata_modified desc'),
                       (_('Name Ascending'), 'title_string asc'),
                       (_('Name Descending'), 'title_string desc'),
@@ -103,6 +104,7 @@
                       (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
                     %}
                     {% set sorting_selected = c.advanced_search.sort_string %}
+                    {% set sorting_selection = c.advanced_search["sorting_selection"] %}
                     <div id="search-results">
                       <div id="search-results-header" class="d-flex flex-wrap justify-content-between align-items-center mt-3">{{_('Found {count} datasets').format(count=c.advanced_search.item_count)}}
                         <div class="form-inline">
@@ -110,11 +112,14 @@
                             <label for="field-order-by">{{ _('Sorting') }}</label>
                             <span class="select-wrapper">
                               <select id="field-order-by" name="sort" class="form-control ytp-input-element avoindata-order-by" data-module="avoindata-utils">
+                                <!-- Default empty option -->
+                                <option disable selected value="auto" {% if not sorting_selection or sorting_selection == "auto" %} selected="selected"{% endif %} style="display:none;"></option>
                                 {% for label, value in sorting %}
                                   {% if label and value %}
-                                    <option value="{{ value }}" {% if sorting_selected == value %} selected="selected" {% endif %}>{{ label }}</option>
+                                    <option value="{{ value }}" {% if sorting_selection == value  %} selected="selected" {% endif %}>{{ label }}</option>
                                   {% endif %}
                                 {% endfor %}
+                                
                               </select>
                             </span>
                           </div>

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -152,8 +152,16 @@ def action_package_show(original_action, context, data_dict):
 @chained_action
 @logic.side_effect_free
 def action_package_search(original_action, context, data_dict):
-    data_dict['sort'] = data_dict.get('sort') or 'metadata_created desc'
-    return original_action(context, data_dict)
+    sort_auto = data_dict.get('sort') in (None, '', 'auto')
+    if sort_auto:
+        data_dict['sort'] = 'score desc' if data_dict.get('q') else 'metadata_created desc'
+
+    result = original_action(context, data_dict)
+
+    if sort_auto:
+        result['sort'] = 'auto'
+
+    return result
 
 
 class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMainTranslation):

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -154,13 +154,12 @@ def action_package_show(original_action, context, data_dict):
 def action_package_search(original_action, context, data_dict):
     sort_auto = data_dict.get('sort') in (None, '', 'auto')
     if sort_auto:
-        data_dict['sort'] = 'score desc' if data_dict.get('q') else 'metadata_created desc'
+        data_dict['sort'] = 'score desc, metadata_modified desc' if data_dict.get('q') else 'metadata_created desc'
 
     result = original_action(context, data_dict)
 
     if sort_auto:
         result['sort'] = 'auto'
-
     return result
 
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/index.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/index.html
@@ -1,5 +1,6 @@
 {% ckan_extends %}
 
+
 {% set sorting = sorting if sorting else [(_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
 {% set organization_filters_count = h.get_organization_filters_count() %}
 
@@ -32,6 +33,7 @@
               <div class="form-select form-group control-order-by">
                 <label for="field-order-by">{{ _('Sorting') }}</label>
                 <select id="field-order-by" name="sort" class="form-control">
+                  <option disable selected value="auto" {% if not sort_by_selected %} selected="selected"{% endif %} style="display:none;"></option>
                   {% for label, value in sorting %}
                     {% if label and value %}
                       <option value="{{ value }}"{% if sort_by_selected == value %} selected="selected"{% endif %}>{{ label }}</option>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/read.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/read.html
@@ -16,6 +16,8 @@
       (_('Name Ascending'), 'title_string asc'),
       (_('Name Descending'), 'title_string desc'),
       (_('Last Modified'), 'metadata_modified desc'),
+      (_('Date Created Ascending'), 'metadata_created asc'),
+      (_('Date Created Descending'), 'metadata_created desc'),
       (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
   %}
   {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=fields %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
@@ -53,6 +53,7 @@
             'remove_field': c.remove_field }
           %}
           {% set sorting = [
+            ('', 'auto'),
             (_('Relevance'), 'score desc, metadata_modified desc'),
             (_('Name Ascending'), 'title_string asc'),
             (_('Name Descending'), 'title_string desc'),

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
@@ -82,7 +82,7 @@
                         <label for="field-order-by">{{ _('Sorting') }}</label>
                         <select id="field-order-by" class="form-control" name="sort">
                             <!-- Default empty option -->
-                            <option disable selected value="auto" {% if not request.params['sort'] %} selected="selected"{% endif %} style="display:none;"></option>
+                            <option disable selected value="auto" {% if not request.params['sort'] or request.params['sort'] == 'auto' %} selected="selected"{% endif %} style="display:none;"></option>
                             {% for label, value in disableable_sorting %}
                                 {% if label and value %}
                                     <option value="{{ value }}"{% if request.params['sort'] == value  %} selected="selected"{% endif %}>{{ label }}</option>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
@@ -81,9 +81,11 @@
                     <div id="field-order-by-container" class="field-order-by-container">
                         <label for="field-order-by">{{ _('Sorting') }}</label>
                         <select id="field-order-by" class="form-control" name="sort">
+                            <!-- Default empty option -->
+                            <option disable selected value="auto" {% if not request.params["sort"] %} selected="selected"{% endif %} style="display:none;"></option>
                             {% for label, value in disableable_sorting %}
                                 {% if label and value %}
-                                    <option value="{{ value }}"{% if sorting_selected == value %} selected="selected"{% endif %}>{{ label }}</option>
+                                    <option value="{{ value }}"{% if request.params['sort'] == value  %} selected="selected"{% endif %}>{{ label }}</option>
                                 {% endif %}
                             {% endfor %}
                         </select>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
@@ -82,7 +82,7 @@
                         <label for="field-order-by">{{ _('Sorting') }}</label>
                         <select id="field-order-by" class="form-control" name="sort">
                             <!-- Default empty option -->
-                            <option disable selected value="auto" {% if not request.params["sort"] %} selected="selected"{% endif %} style="display:none;"></option>
+                            <option disable selected value="auto" {% if not request.params['sort'] %} selected="selected"{% endif %} style="display:none;"></option>
                             {% for label, value in disableable_sorting %}
                                 {% if label and value %}
                                     <option value="{{ value }}"{% if request.params['sort'] == value  %} selected="selected"{% endif %}>{{ label }}</option>


### PR DESCRIPTION
Sorting on the following pages now defaults to having an empty option field chosen while sorting. 

- dataset
- dataset advanced search
- organization (only empty default field, uses name sorting by default)
- organization dataset
- showcase
- category

If there isn't a text search, the sorting defaults to sorting by creation date. If there is a text search, the default is by score.  
![image](https://user-images.githubusercontent.com/24498487/177103798-1eb6fabd-5771-4278-9b86-5b07aa247f4f.png)
