### PR TITLE
fix(AV-1746): Removed spatial search from apisets page

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
@@ -102,7 +102,9 @@
   <div class="secondary__header">
     <h3 class="secondary__title">{{ _('Filter list') }}</h3>
   </div>
-  {% snippet "spatial/snippets/spatial_query.html", default_extent="[[59.85, 20.65], [70.16, 31.52]]" %}
+  {% if dataset_type != 'apiset'%}
+    {% snippet "spatial/snippets/spatial_query.html", default_extent="[[59.85, 20.65], [70.16, 31.52]]" %}
+  {% endif %}
   {% for facet in c.facet_titles %}
     {% set title = c.facet_titles[facet] or h.get_facet_title(name) %}
     {% if facet.startswith('vocab_content_type_')  %}


### PR DESCRIPTION
Removed the spatial search from apisets page
![image](https://user-images.githubusercontent.com/24498487/177126369-12befccd-51e7-4db4-95c7-a6083e7ec32a.png)
