### PR TITLE
fix(AV-1741): Removing avoindata.fi keyword

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -439,7 +439,6 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
         # Map keywords to vocab_keywords_{lang}
         translated_vocabs = ['keywords', 'content_type']
         languages = ['fi', 'sv', 'en']
-        # Tags that should not be indexed 
         ignored_tags = ["avoindata.fi"]
         for prop_key in translated_vocabs:
             prop_json = pkg_dict.get(prop_key)
@@ -463,7 +462,6 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
                 pkg_dict['producer_type'] = org['producer_type']
 
         return pkg_dict
-
 
     def before_view(self, pkg_dict):
         # remove unwanted keywords from being passed to the view


### PR DESCRIPTION
The "avoindata.fi" keyword will no longer appear as a keyword, nor will appear when opening datasets. It still exists in datasets and can be added to them, but it will not appear as a visible filter option.