### PR TITLE
fix(AV-1105): Edit category page active fix

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/group_list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/group_list.html
@@ -1,15 +1,10 @@
 {% ckan_extends %}
 
 {% block content_primary_nav %}
-
-{{ super() }}
-<!-- Add the active element to category <li> -->
-  <script>
-      let head_list = document.querySelectorAll('.nav.nav-tabs > li');
-      head_list[1].classList.add("active");
-  </script>
+  {{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'), id=pkg.id if is_activity_archive else pkg.name, icon='sitemap') }}
+  {{ h.build_nav_icon(dataset_type ~ '.groups', _('Groups'), id=pkg.id if is_activity_archive else pkg.name, controller='ytp_main_dataset', icon='users') }}
+  {{ h.build_nav_icon(dataset_type ~ '.activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock-o') }}
 {% endblock %}
-
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{{ _('Groups') }}</h2>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/group_list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/group_list.html
@@ -1,4 +1,16 @@
 {% ckan_extends %}
+
+{% block content_primary_nav %}
+
+{{ super() }}
+<!-- Add the active element to category <li> -->
+  <script>
+      let head_list = document.querySelectorAll('.nav.nav-tabs > li');
+      head_list[1].classList.add("active");
+  </script>
+{% endblock %}
+
+
 {% block primary_content_inner %}
   <h2 class="hide-heading">{{ _('Groups') }}</h2>
 


### PR DESCRIPTION
Category is now selected as the active tab when editing the category. There is an issue with ckan's helper function not recognizing  the tab as active when using the build_nav_icon function, so the active selection is done client-side afterwards.

![image](https://user-images.githubusercontent.com/24498487/178486245-38931ae2-2ec8-4b6a-802e-e2b520626966.png)
