### PR TITLE
fix(AV-1665): dataset api instructions change

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-14 13:07+0000\n"
+"POT-Creation-Date: 2022-07-13 10:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,47 +18,47 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.7.0\n"
 
-#: ckanext/ytp/auth.py:17 ckanext/ytp/auth.py:31
+#: ckanext/ytp/auth.py:18 ckanext/ytp/auth.py:32
 msgid "Only the owner can update a related item"
 msgstr ""
 
-#: ckanext/ytp/auth.py:36
+#: ckanext/ytp/auth.py:37
 msgid "You must be a sysadmin to change a related item's featured field."
 msgstr ""
 
-#: ckanext/ytp/auth.py:53
+#: ckanext/ytp/auth.py:54
 msgid "You must be a sysadmin to create a featured related item"
 msgstr ""
 
-#: ckanext/ytp/auth.py:61 ckanext/ytp/auth.py:64
+#: ckanext/ytp/auth.py:62 ckanext/ytp/auth.py:65
 msgid "You must be logged in to add a related item"
 msgstr ""
 
-#: ckanext/ytp/auth.py:71 ckanext/ytp/auth.py:76
+#: ckanext/ytp/auth.py:72 ckanext/ytp/auth.py:77
 #, python-format
 msgid "User %s not authorized to create public organizations"
 msgstr ""
 
-#: ckanext/ytp/auth.py:89
+#: ckanext/ytp/auth.py:90
 msgid "Only registered users can create organizations"
 msgstr ""
 
-#: ckanext/ytp/auth.py:104 ckanext/ytp/validators.py:468
+#: ckanext/ytp/auth.py:105 ckanext/ytp/validators.py:468
 #, python-format
 msgid "User %s is not administrator in the selected parent organization"
 msgstr ""
 
-#: ckanext/ytp/auth.py:113
+#: ckanext/ytp/auth.py:114
 #, python-format
 msgid "User %s not authorized to create organizations"
 msgstr ""
 
-#: ckanext/ytp/auth.py:133
+#: ckanext/ytp/auth.py:136
 msgid "Cannot modify dataset because of organization policy"
 msgstr ""
 
-#: ckanext/ytp/auth.py:141 ckanext/ytp/views_organization.py:219
-#: ckanext/ytp/views_organization.py:267
+#: ckanext/ytp/auth.py:144 ckanext/ytp/views_organization.py:275
+#: ckanext/ytp/views_organization.py:323
 msgid "Only system administrators are allowed to view user list."
 msgstr ""
 
@@ -164,7 +164,7 @@ msgid "Related item was successfully updated"
 msgstr ""
 
 #: ckanext/ytp/controller.py:419 ckanext/ytp/controller.py:691
-#: ckanext/ytp/views_organization.py:76
+#: ckanext/ytp/views_organization.py:77
 msgid "Integrity Error"
 msgstr ""
 
@@ -240,11 +240,11 @@ msgstr ""
 msgid "Date format incorrect"
 msgstr ""
 
-#: ckanext/ytp/helpers.py:98 ckanext/ytp/plugin.py:322
+#: ckanext/ytp/helpers.py:103 ckanext/ytp/plugin.py:321
 msgid "Unnamed resource"
 msgstr ""
 
-#: ckanext/ytp/helpers.py:578
+#: ckanext/ytp/helpers.py:583
 msgid "-"
 msgstr ""
 
@@ -310,8 +310,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: ckanext/ytp/menu.py:155 ckanext/ytp/plugin.py:270
-#: ckanext/ytp/templates/organization/admin_list.html:31
+#: ckanext/ytp/menu.py:155 ckanext/ytp/templates/organization/admin_list.html:31
 #: ckanext/ytp/templates/organization/edit.html:4
 #: ckanext/ytp/templates/organization/index.html:13
 #: ckanext/ytp/templates/organization/organization_not_found.html:6
@@ -341,43 +340,55 @@ msgstr ""
 msgid "Publish Data"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:266
+#: ckanext/ytp/plugin.py:265
 msgid "International Benchmarks"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:267 ckanext/ytp/plugin.py:281
+#: ckanext/ytp/plugin.py:266 ckanext/ytp/translations.py:68
+msgid "Geographical coverage"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:267 ckanext/ytp/plugin.py:280
 msgid "Collection Types"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:268
-msgid "Popular Tags"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:269 ckanext/ytp/plugin.py:283
-msgid "Content Types"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:271 ckanext/ytp/plugin.py:284
-#: ckanext/ytp/translations.py:35
-msgid "Formats"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:273
-msgid "Sources"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:274
-msgid "Licenses"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:282
+#: ckanext/ytp/plugin.py:268 ckanext/ytp/plugin.py:281
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:14
 msgid "Tags"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:322
+#: ckanext/ytp/plugin.py:269
+#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
+#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
+#: ckanext/ytp/templates/snippets/organization.html:21
+#: ckanext/ytp/translations.py:36
+msgid "Organization"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:270 ckanext/ytp/plugin.py:283
+#: ckanext/ytp/translations.py:35
+msgid "Formats"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:271
+msgid "Licenses"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:272
+msgid "Category"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:273 ckanext/ytp/translations.py:87
+msgid "Producer type"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:282
+msgid "Content Types"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:321
 #: ckanext/ytp/templates/package/snippets/additional_info.html:2
-#: ckanext/ytp/templates/scheming/organization/about.html:18
+#: ckanext/ytp/templates/scheming/organization/about.html:20
 msgid "Additional Info"
 msgstr ""
 
@@ -441,7 +452,7 @@ msgstr ""
 msgid "Internal"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:230
+#: ckanext/ytp/templates/package/resource_read.html:252
 #: ckanext/ytp/templates/package/snippets/additional_info.html:68
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:8
 #: ckanext/ytp/translations.py:28
@@ -471,13 +482,6 @@ msgstr ""
 
 #: ckanext/ytp/translations.py:34
 msgid "Size"
-msgstr ""
-
-#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
-#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
-#: ckanext/ytp/templates/snippets/organization.html:21
-#: ckanext/ytp/translations.py:36
-msgid "Organization"
 msgstr ""
 
 #: ckanext/ytp/translations.py:37
@@ -596,10 +600,6 @@ msgstr ""
 msgid "Copyright notice"
 msgstr ""
 
-#: ckanext/ytp/translations.py:68
-msgid "Geographical coverage"
-msgstr ""
-
 #: ckanext/ytp/translations.py:69
 msgid "Select the municipalities from which the dataset contains data."
 msgstr ""
@@ -671,10 +671,6 @@ msgstr ""
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:20
 #: ckanext/ytp/translations.py:86
 msgid "Categories"
-msgstr ""
-
-#: ckanext/ytp/translations.py:87
-msgid "Producer type"
 msgstr ""
 
 #: ckanext/ytp/translations.py:88
@@ -1534,21 +1530,22 @@ msgstr ""
 msgid "Only sysadmin can change feature: %s"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:53
+#: ckanext/ytp/views_organization.py:54
 msgid "Unauthorized to create a group"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:74 ckanext/ytp/views_organization.py:114
-#: ckanext/ytp/views_organization.py:161 ckanext/ytp/views_organization.py:342
+#: ckanext/ytp/views_organization.py:75 ckanext/ytp/views_organization.py:104
+#: ckanext/ytp/views_organization.py:170 ckanext/ytp/views_organization.py:217
+#: ckanext/ytp/views_organization.py:398
 msgid "Group not found"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:164
+#: ckanext/ytp/views_organization.py:220
 #, python-format
 msgid "User %r not authorized to edit members of %s"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:288
+#: ckanext/ytp/views_organization.py:344
 msgid "Not authorized to see this page"
 msgstr ""
 
@@ -1589,7 +1586,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: ckanext/ytp/resources/opendata/scripts/slug-preview-ex.js:53
+#: ckanext/ytp/resources/opendata/scripts/slug-preview-ex.js:59
 #: ckanext/ytp/templates/organization/admin_list.html:50
 #: ckanext/ytp/templates/organization/bulk_process.html:47
 #: ckanext/ytp/templates/organization/members.html:35
@@ -1669,24 +1666,24 @@ msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:105
 #: ckanext/ytp/templates/organization/read_base.html:37
-#: ckanext/ytp/templates/package/resource_read.html:64
+#: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:9
 #: ckanext/ytp/templates/package/snippets/resource_item3.html:9
 msgid "Manage"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:111
-#: ckanext/ytp/templates/package/resource_read.html:70
+#: ckanext/ytp/templates/package/resource_read.html:72
 msgid "View"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:113
-#: ckanext/ytp/templates/package/resource_read.html:72
+#: ckanext/ytp/templates/package/resource_read.html:74
 msgid "API Endpoint"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:115
-#: ckanext/ytp/templates/package/resource_read.html:74
+#: ckanext/ytp/templates/package/resource_read.html:76
 #: ckanext/ytp/templates/package/snippets/related_item.html:65
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:13
 #: ckanext/ytp/templates/package/snippets/resource_item3.html:11
@@ -1694,19 +1691,19 @@ msgid "Open"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:117
-#: ckanext/ytp/templates/package/resource_read.html:76
+#: ckanext/ytp/templates/package/resource_read.html:78
 #: ckanext/ytp/templates/package/snippets/resource_item.html:51
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:15
 msgid "Download"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:139
-#: ckanext/ytp/templates/package/resource_read.html:109
+#: ckanext/ytp/templates/package/resource_read.html:113
 msgid "From the dataset abstract"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:141
-#: ckanext/ytp/templates/package/resource_read.html:111
+#: ckanext/ytp/templates/package/resource_read.html:115
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr ""
@@ -2119,107 +2116,107 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 #, python-format
 msgid "<a href=\"%(url)s\">"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 msgid "dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:89
+#: ckanext/ytp/templates/package/resource_read.html:93
 #, python-format
 msgid "%(dataset)s"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:135
+#: ckanext/ytp/templates/package/resource_read.html:157
 #: ckanext/ytp/templates/package/snippets/resource_item.html:40
 #: ckanext/ytp/templates/snippets/datapreview_embed_dialog.html:18
 msgid "Preview"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:155
+#: ckanext/ytp/templates/package/resource_read.html:177
 msgid "There are no views created for this resource yet."
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:159
+#: ckanext/ytp/templates/package/resource_read.html:181
 msgid "Not seeing the views you were expecting?"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:161
+#: ckanext/ytp/templates/package/resource_read.html:183
 #: ckanext/ytp/templates/package/snippets/resource_view.html:26
 msgid "Click here for more information."
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:164
+#: ckanext/ytp/templates/package/resource_read.html:186
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:166
+#: ckanext/ytp/templates/package/resource_read.html:188
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:167
+#: ckanext/ytp/templates/package/resource_read.html:189
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/resource_read.html:190
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, or"
 " the data may not have been pushed to the DataStore, or the DataStore hasn't "
 "finished processing the data yet"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:184
+#: ckanext/ytp/templates/package/resource_read.html:206
 msgid "Extra information"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:188
+#: ckanext/ytp/templates/package/resource_read.html:210
 #: ckanext/ytp/templates/package/snippets/resource_form.html:31
 msgid "Format"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:189
-#: ckanext/ytp/templates/package/resource_read.html:227
-#: ckanext/ytp/templates/package/resource_read.html:231
-#: ckanext/ytp/templates/package/resource_read.html:235
+#: ckanext/ytp/templates/package/resource_read.html:211
+#: ckanext/ytp/templates/package/resource_read.html:249
+#: ckanext/ytp/templates/package/resource_read.html:253
+#: ckanext/ytp/templates/package/resource_read.html:257
 msgid "unknown"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:220
+#: ckanext/ytp/templates/package/resource_read.html:242
 msgid "Temporal Coverage"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:226
+#: ckanext/ytp/templates/package/resource_read.html:248
 msgid "Last updated"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:234
+#: ckanext/ytp/templates/package/resource_read.html:256
 msgid "sha256"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:264
+#: ckanext/ytp/templates/package/resource_read.html:286
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:111
 msgid "Stats"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:265
+#: ckanext/ytp/templates/package/resource_read.html:287
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:112
 msgid "Last 30 days, updated daily"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:268
+#: ckanext/ytp/templates/package/resource_read.html:290
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:119
 msgid "All time downloads:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:278
+#: ckanext/ytp/templates/package/resource_read.html:300
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:127
 msgid "Year"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:278
+#: ckanext/ytp/templates/package/resource_read.html:300
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:127
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:11
 msgid "Downloads"
@@ -2313,7 +2310,7 @@ msgid "Show more categories"
 msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/categories.html:34
-#: ckanext/ytp/templates/snippets/facet_list.html:84
+#: ckanext/ytp/templates/snippets/facet_list.html:93
 msgid "Show more"
 msgstr ""
 
@@ -2384,6 +2381,14 @@ msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:43
 msgid "https://creativecommons.org/licenses/by/4.0/"
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/new_data_api_button.html:7
+msgid "Loading..."
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/new_data_api_button.html:9
+msgid "Data API Instructions"
 msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/package_form.html:30
@@ -2457,7 +2462,7 @@ msgid "eg. January 2011 Gold Prices"
 msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/resource_form.html:26
-#: ckanext/ytp/templates/scheming/organization/about.html:14
+#: ckanext/ytp/templates/scheming/organization/about.html:16
 msgid "Description"
 msgstr ""
 
@@ -2751,7 +2756,7 @@ msgid ""
 "odt, ods, txt."
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/organization/about.html:36
+#: ckanext/ytp/templates/scheming/organization/about.html:38
 msgid "Logo of organization {org}"
 msgstr ""
 
@@ -2955,11 +2960,11 @@ msgstr ""
 msgid "Height:"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/facet_list.html:87
+#: ckanext/ytp/templates/snippets/facet_list.html:96
 msgid "Show less"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/facet_list.html:91
+#: ckanext/ytp/templates/snippets/facet_list.html:100
 msgid "There are no {facet_type} that match this search"
 msgstr ""
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
@@ -11,15 +11,16 @@
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
 # Daniel Vainio, 2021
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
+# Ville Teräväinen, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-10 09:54+0000\n"
+"POT-Creation-Date: 2022-07-13 10:02+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Meeri Hakala <meeri.hakala@dvv.fi>, 2022\n"
+"Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,47 +29,47 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/ytp/auth.py:17 ckanext/ytp/auth.py:31
+#: ckanext/ytp/auth.py:18 ckanext/ytp/auth.py:32
 msgid "Only the owner can update a related item"
 msgstr ""
 
-#: ckanext/ytp/auth.py:36
+#: ckanext/ytp/auth.py:37
 msgid "You must be a sysadmin to change a related item's featured field."
 msgstr ""
 
-#: ckanext/ytp/auth.py:53
+#: ckanext/ytp/auth.py:54
 msgid "You must be a sysadmin to create a featured related item"
 msgstr ""
 
-#: ckanext/ytp/auth.py:61 ckanext/ytp/auth.py:64
+#: ckanext/ytp/auth.py:62 ckanext/ytp/auth.py:65
 msgid "You must be logged in to add a related item"
 msgstr ""
 
-#: ckanext/ytp/auth.py:71 ckanext/ytp/auth.py:76
+#: ckanext/ytp/auth.py:72 ckanext/ytp/auth.py:77
 #, python-format
 msgid "User %s not authorized to create public organizations"
 msgstr "User %s not authorized to create public organisations"
 
-#: ckanext/ytp/auth.py:89
+#: ckanext/ytp/auth.py:90
 msgid "Only registered users can create organizations"
 msgstr "Only registered users can create organisations"
 
-#: ckanext/ytp/auth.py:104 ckanext/ytp/validators.py:468
+#: ckanext/ytp/auth.py:105 ckanext/ytp/validators.py:468
 #, python-format
 msgid "User %s is not administrator in the selected parent organization"
 msgstr "User %s is not administrator in the selected parent organisation"
 
-#: ckanext/ytp/auth.py:113
+#: ckanext/ytp/auth.py:114
 #, python-format
 msgid "User %s not authorized to create organizations"
 msgstr "User %s not authorized to create organisations"
 
-#: ckanext/ytp/auth.py:133
+#: ckanext/ytp/auth.py:136
 msgid "Cannot modify dataset because of organization policy"
 msgstr "Cannot modify dataset because of organisation policy"
 
-#: ckanext/ytp/auth.py:141 ckanext/ytp/views_organization.py:219
-#: ckanext/ytp/views_organization.py:267
+#: ckanext/ytp/auth.py:144 ckanext/ytp/views_organization.py:275
+#: ckanext/ytp/views_organization.py:323
 msgid "Only system administrators are allowed to view user list."
 msgstr ""
 
@@ -174,11 +175,11 @@ msgid "Related item was successfully updated"
 msgstr ""
 
 #: ckanext/ytp/controller.py:419 ckanext/ytp/controller.py:691
-#: ckanext/ytp/views_organization.py:76
+#: ckanext/ytp/views_organization.py:77
 msgid "Integrity Error"
 msgstr ""
 
-#: ckanext/ytp/controller.py:439 ckanext/ytp/templates/package/search.html:84
+#: ckanext/ytp/controller.py:439 ckanext/ytp/templates/package/search.html:83
 #: ckanext/ytp/templates/package/snippets/related_item.html:21
 msgid "API"
 msgstr ""
@@ -250,11 +251,11 @@ msgstr ""
 msgid "Date format incorrect"
 msgstr ""
 
-#: ckanext/ytp/helpers.py:98 ckanext/ytp/plugin.py:322
+#: ckanext/ytp/helpers.py:103 ckanext/ytp/plugin.py:321
 msgid "Unnamed resource"
 msgstr ""
 
-#: ckanext/ytp/helpers.py:578
+#: ckanext/ytp/helpers.py:583
 msgid "-"
 msgstr ""
 
@@ -321,7 +322,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: ckanext/ytp/menu.py:155 ckanext/ytp/plugin.py:270
+#: ckanext/ytp/menu.py:155
 #: ckanext/ytp/templates/organization/admin_list.html:31
 #: ckanext/ytp/templates/organization/edit.html:4
 #: ckanext/ytp/templates/organization/index.html:13
@@ -352,43 +353,55 @@ msgstr ""
 msgid "Publish Data"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:266
+#: ckanext/ytp/plugin.py:265
 msgid "International Benchmarks"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:267 ckanext/ytp/plugin.py:281
+#: ckanext/ytp/plugin.py:266 ckanext/ytp/translations.py:68
+msgid "Geographical coverage"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:267 ckanext/ytp/plugin.py:280
 msgid "Collection Types"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:268
-msgid "Popular Tags"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:269 ckanext/ytp/plugin.py:283
-msgid "Content Types"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:271 ckanext/ytp/plugin.py:284
-#: ckanext/ytp/translations.py:35
-msgid "Formats"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:273
-msgid "Sources"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:274
-msgid "Licenses"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:282
+#: ckanext/ytp/plugin.py:268 ckanext/ytp/plugin.py:281
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:14
 msgid "Tags"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:322
+#: ckanext/ytp/plugin.py:269
+#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
+#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
+#: ckanext/ytp/templates/snippets/organization.html:21
+#: ckanext/ytp/translations.py:36
+msgid "Organization"
+msgstr "Publisher"
+
+#: ckanext/ytp/plugin.py:270 ckanext/ytp/plugin.py:283
+#: ckanext/ytp/translations.py:35
+msgid "Formats"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:271
+msgid "Licenses"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:272
+msgid "Category"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:273 ckanext/ytp/translations.py:87
+msgid "Producer type"
+msgstr "Regional coverage / Producer type"
+
+#: ckanext/ytp/plugin.py:282
+msgid "Content Types"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:321
 #: ckanext/ytp/templates/package/snippets/additional_info.html:2
-#: ckanext/ytp/templates/scheming/organization/about.html:18
+#: ckanext/ytp/templates/scheming/organization/about.html:20
 msgid "Additional Info"
 msgstr ""
 
@@ -452,7 +465,7 @@ msgstr ""
 msgid "Internal"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:230
+#: ckanext/ytp/templates/package/resource_read.html:252
 #: ckanext/ytp/templates/package/snippets/additional_info.html:68
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:8
 #: ckanext/ytp/translations.py:28
@@ -483,13 +496,6 @@ msgstr ""
 #: ckanext/ytp/translations.py:34
 msgid "Size"
 msgstr ""
-
-#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
-#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
-#: ckanext/ytp/templates/snippets/organization.html:21
-#: ckanext/ytp/translations.py:36
-msgid "Organization"
-msgstr "Publisher"
 
 #: ckanext/ytp/translations.py:37
 msgid "Key"
@@ -613,10 +619,6 @@ msgstr ""
 msgid "Copyright notice"
 msgstr ""
 
-#: ckanext/ytp/translations.py:68
-msgid "Geographical coverage"
-msgstr ""
-
 #: ckanext/ytp/translations.py:69
 msgid "Select the municipalities from which the dataset contains data."
 msgstr ""
@@ -689,10 +691,6 @@ msgstr ""
 #: ckanext/ytp/translations.py:86
 msgid "Categories"
 msgstr ""
-
-#: ckanext/ytp/translations.py:87
-msgid "Producer type"
-msgstr "Regional coverage / Producer type"
 
 #: ckanext/ytp/translations.py:88
 msgid "Public administration organization"
@@ -1108,7 +1106,7 @@ msgstr ""
 
 #: ckanext/ytp/translations.py:203
 msgid "Dataset visibility"
-msgstr ""
+msgstr "Dataset visibility in opendata.fi"
 
 #: ckanext/ytp/translations.py:204
 msgid ""
@@ -1184,25 +1182,61 @@ msgstr ""
 msgid "e.g. avoindata@dvv.fi"
 msgstr ""
 
+#: ckanext/ytp/translations.py:219
+msgid ""
+"Deleted. The dataset is only visible to logged in users of the producer "
+"organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:220
+msgid ""
+"In draft state. The dataset is only visible to logged in users of the "
+"producer organization."
+msgstr ""
+
 #: ckanext/ytp/translations.py:221
-msgid "Data resource title"
+msgid ""
+"Private mode. The dataset is only visible to logged in users of the producer"
+" organization."
 msgstr ""
 
 #: ckanext/ytp/translations.py:222
+msgid ""
+"Deleted. The apiset is only visible to logged in users of the producer "
+"organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:223
+msgid ""
+"In draft state. The apiset is only visible to logged in users of the "
+"producer organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:224
+msgid ""
+"Private mode. The apiset is only visible to logged in users of the producer "
+"organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:227
+msgid "Data resource title"
+msgstr ""
+
+#: ckanext/ytp/translations.py:228
 msgid ""
 "Write a short and descriptive name for the data resource. If the data covers"
 " a specific time frame, mention that in the name."
 msgstr ""
 
-#: ckanext/ytp/translations.py:223
+#: ckanext/ytp/translations.py:229
 msgid "e.g. Most popular Finnish first names 2019"
 msgstr ""
 
-#: ckanext/ytp/translations.py:224
+#: ckanext/ytp/translations.py:230
 msgid "Resource *"
 msgstr ""
 
-#: ckanext/ytp/translations.py:225
+#: ckanext/ytp/translations.py:231
 msgid ""
 "Add the data resource by uploading a file or adding a link to the "
 "data.<br>Select or drag the files here.<br>The maximum file size is 5 Gb. "
@@ -1213,271 +1247,273 @@ msgstr ""
 "data.<br>The maximum file size is 5 Gb. Valid data formats are e.g. pdf, "
 "jpg, jpeg, png, doc, docx, xls, xlsx, csv, ppt, pptx, odt, ods, txt."
 
-#: ckanext/ytp/translations.py:226
+#: ckanext/ytp/translations.py:232
 msgid "Data resource description"
 msgstr ""
 
-#: ckanext/ytp/translations.py:227
+#: ckanext/ytp/translations.py:233
 msgid "Write a description for the resource"
 msgstr ""
 
-#: ckanext/ytp/translations.py:228
+#: ckanext/ytp/translations.py:234
 msgid ""
 "Describe the data clearly and concisely. Use as confining terms as possible "
 "to make it easier to find and understand the data."
 msgstr ""
 
-#: ckanext/ytp/translations.py:229
+#: ckanext/ytp/translations.py:235
 msgid "Additional information"
 msgstr ""
 
-#: ckanext/ytp/translations.py:230
+#: ckanext/ytp/translations.py:236
 msgid "Data status"
 msgstr ""
 
-#: ckanext/ytp/translations.py:231
+#: ckanext/ytp/translations.py:237
 msgid ""
 "Define a state for the data. This is recommended especially if your dataset "
 "has data resources from multiple years."
 msgstr ""
 
-#: ckanext/ytp/translations.py:232
+#: ckanext/ytp/translations.py:238
 msgid "Coordinate system"
 msgstr ""
 
-#: ckanext/ytp/translations.py:233
+#: ckanext/ytp/translations.py:239
 msgid ""
 "If your data includes geographic information, specify the coordinate system "
 "it uses."
 msgstr ""
 
-#: ckanext/ytp/translations.py:234
+#: ckanext/ytp/translations.py:240
 msgid "e.g. WGS84 (World Geodetic System 1984)"
 msgstr ""
 
-#: ckanext/ytp/translations.py:235
+#: ckanext/ytp/translations.py:241
 msgid ""
 "Select the time frame by which the data is separated. For example, does the "
 "resource include data from every week or month."
 msgstr ""
 
-#: ckanext/ytp/translations.py:236
+#: ckanext/ytp/translations.py:242
 msgid "e.g. a month"
 msgstr ""
 
-#: ckanext/ytp/translations.py:237
+#: ckanext/ytp/translations.py:243
 msgid "Time Frame"
 msgstr ""
 
-#: ckanext/ytp/translations.py:238
+#: ckanext/ytp/translations.py:244
 msgid "Start date"
 msgstr ""
 
-#: ckanext/ytp/translations.py:239
+#: ckanext/ytp/translations.py:245
 msgid "End date"
 msgstr ""
 
-#: ckanext/ytp/translations.py:242
+#: ckanext/ytp/translations.py:248
 msgid "Producer name"
 msgstr ""
 
-#: ckanext/ytp/translations.py:243
+#: ckanext/ytp/translations.py:249
 msgid "Producer description"
 msgstr ""
 
-#: ckanext/ytp/translations.py:244
+#: ckanext/ytp/translations.py:250
 msgid "Common, compact and plain description about producer"
 msgstr ""
+"Describe what your organisation does and what kind of services and data it "
+"produces."
 
-#: ckanext/ytp/translations.py:245
+#: ckanext/ytp/translations.py:251
 msgid "Other information"
 msgstr ""
 
-#: ckanext/ytp/translations.py:248
+#: ckanext/ytp/translations.py:254
 msgid "cc-by"
 msgstr "Creative Commons Attribution"
 
-#: ckanext/ytp/translations.py:249
+#: ckanext/ytp/translations.py:255
 msgid "cc-by-4-fi"
 msgstr "Creative Commons Nimeä 4.0"
 
-#: ckanext/ytp/translations.py:250
+#: ckanext/ytp/translations.py:256
 msgid "cc-by-4.0"
 msgstr "Creative Commons Attribution 4.0"
 
-#: ckanext/ytp/translations.py:251
+#: ckanext/ytp/translations.py:257
 msgid "cc-by-sa"
 msgstr "Creative Commons Attribution Share-Alike"
 
-#: ckanext/ytp/translations.py:252
+#: ckanext/ytp/translations.py:258
 msgid "cc-by-sa-1-fi"
 msgstr "Creative Commons Nimeä-Tarttuva 1.0 Suomi (CC BY-SA 1.0)"
 
-#: ckanext/ytp/translations.py:253
+#: ckanext/ytp/translations.py:259
 msgid "cc-nc"
 msgstr "Creative Commons Non-Commercial (Any)"
 
-#: ckanext/ytp/translations.py:254
+#: ckanext/ytp/translations.py:260
 msgid "cc-zero"
 msgstr "Creative Commons CCZero"
 
-#: ckanext/ytp/translations.py:255
+#: ckanext/ytp/translations.py:261
 msgid "cc-zero-1.0"
 msgstr "Creative Commons CCZero 1.0"
 
-#: ckanext/ytp/translations.py:256
+#: ckanext/ytp/translations.py:262
 msgid "gfdl"
 msgstr "GNU Free Documentation License"
 
-#: ckanext/ytp/translations.py:257
+#: ckanext/ytp/translations.py:263
 msgid "helsinkikanava-opendata-tos"
 msgstr "Helsinkikanava Open Data käyttöehdot"
 
-#: ckanext/ytp/translations.py:258
+#: ckanext/ytp/translations.py:264
 msgid "hri-tietoaineistot-lisenssi-nimea"
 msgstr "HRI - tietoaineistojen lisenssi - nimeä"
 
-#: ckanext/ytp/translations.py:259
+#: ckanext/ytp/translations.py:265
 msgid "ilmoitettumuualla"
 msgstr "Lisenssi ilmoitettu tietoaineiston ylläpitäjän palvelussa"
 
-#: ckanext/ytp/translations.py:260
+#: ckanext/ytp/translations.py:266
 msgid "kmo-aluejakorajat"
 msgstr "KMO aluejakorajojen vektoriaineistojen käyttöehdot"
 
-#: ckanext/ytp/translations.py:261
+#: ckanext/ytp/translations.py:267
 msgid "notspecified"
 msgstr "License Not Specified"
 
-#: ckanext/ytp/translations.py:262
+#: ckanext/ytp/translations.py:268
 msgid "odc-by"
 msgstr "Open Data Commons Attribution License"
 
-#: ckanext/ytp/translations.py:263
+#: ckanext/ytp/translations.py:269
 msgid "odc-odbl"
 msgstr "Open Data Commons Open Database License (ODbL)"
 
-#: ckanext/ytp/translations.py:264
+#: ckanext/ytp/translations.py:270
 msgid "odc-pddl"
 msgstr "Open Data Commons Public Domain Dedication and Licence (PDDL)"
 
-#: ckanext/ytp/translations.py:265
+#: ckanext/ytp/translations.py:271
 msgid "other"
 msgstr "Other"
 
-#: ckanext/ytp/translations.py:266
+#: ckanext/ytp/translations.py:272
 msgid "other-at"
 msgstr "Other (Attribution)"
 
-#: ckanext/ytp/translations.py:267
+#: ckanext/ytp/translations.py:273
 msgid "other-closed"
 msgstr "Other (Not Open)"
 
-#: ckanext/ytp/translations.py:268
+#: ckanext/ytp/translations.py:274
 msgid "other-nc"
 msgstr "Other (Non-Commercial)"
 
-#: ckanext/ytp/translations.py:269
+#: ckanext/ytp/translations.py:275
 msgid "other-open"
 msgstr "Other (Open)"
 
-#: ckanext/ytp/translations.py:270
+#: ckanext/ytp/translations.py:276
 msgid "other-pd"
 msgstr "Other (Public Domain)"
 
-#: ckanext/ytp/translations.py:271
+#: ckanext/ytp/translations.py:277
 msgid "uk-ogl"
 msgstr "UK Open Government Licence (OGL)"
 
-#: ckanext/ytp/translations.py:274
+#: ckanext/ytp/translations.py:280
 msgid "Platforms"
 msgstr ""
 
-#: ckanext/ytp/translations.py:277
+#: ckanext/ytp/translations.py:283
 msgid "Show more collection_type"
 msgstr "Show more Collection Types"
 
-#: ckanext/ytp/translations.py:278
+#: ckanext/ytp/translations.py:284
 msgid "Show more vocab_international_benchmarks"
 msgstr "Show more International Benchmarks"
 
-#: ckanext/ytp/translations.py:279
+#: ckanext/ytp/translations.py:285
 msgid "Show more vocab_keywords_en"
 msgstr "Show more Keywords"
 
-#: ckanext/ytp/translations.py:280
+#: ckanext/ytp/translations.py:286
 msgid "Show more vocab_keywords_fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:281
+#: ckanext/ytp/translations.py:287
 msgid "Show more vocab_keywords_sv"
 msgstr ""
 
-#: ckanext/ytp/translations.py:282
+#: ckanext/ytp/translations.py:288
 msgid "Show more organization"
 msgstr "Show more Publishers"
 
-#: ckanext/ytp/translations.py:283
+#: ckanext/ytp/translations.py:289
 msgid "Show more res_format"
 msgstr "Show more Formats"
 
-#: ckanext/ytp/translations.py:284
+#: ckanext/ytp/translations.py:290
 msgid "Show more source"
 msgstr "Show more Sources"
 
-#: ckanext/ytp/translations.py:285
+#: ckanext/ytp/translations.py:291
 msgid "Show more license_id"
 msgstr "Show more Licenses"
 
-#: ckanext/ytp/translations.py:286
+#: ckanext/ytp/translations.py:292
 msgid "Show more groups"
 msgstr "Show more Groups"
 
-#: ckanext/ytp/translations.py:287
+#: ckanext/ytp/translations.py:293
 msgid "Show more vocab_platform"
 msgstr "Show more Platforms"
 
-#: ckanext/ytp/translations.py:290
+#: ckanext/ytp/translations.py:296
 msgid "Show less collection_type"
 msgstr "Show less Collection Types"
 
-#: ckanext/ytp/translations.py:291
+#: ckanext/ytp/translations.py:297
 msgid "Show less vocab_international_benchmarks"
 msgstr "Show less International Benchmarks"
 
-#: ckanext/ytp/translations.py:292
+#: ckanext/ytp/translations.py:298
 msgid "Show less vocab_keywords_en"
 msgstr "Show less Keywords"
 
-#: ckanext/ytp/translations.py:293
+#: ckanext/ytp/translations.py:299
 msgid "Show less vocab_keywords_fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:294
+#: ckanext/ytp/translations.py:300
 msgid "Show less vocab_keywords_sv"
 msgstr ""
 
-#: ckanext/ytp/translations.py:295
+#: ckanext/ytp/translations.py:301
 msgid "Show less organization"
 msgstr "Show less Publishers"
 
-#: ckanext/ytp/translations.py:296
+#: ckanext/ytp/translations.py:302
 msgid "Show less res_format"
 msgstr "Show less Formats"
 
-#: ckanext/ytp/translations.py:297
+#: ckanext/ytp/translations.py:303
 msgid "Show less source"
 msgstr "Show less Sources"
 
-#: ckanext/ytp/translations.py:298
+#: ckanext/ytp/translations.py:304
 msgid "Show less license_id"
 msgstr "Show less Licenses"
 
-#: ckanext/ytp/translations.py:299
+#: ckanext/ytp/translations.py:305
 msgid "Show less groups"
 msgstr "Show less Groups"
 
-#: ckanext/ytp/translations.py:300
+#: ckanext/ytp/translations.py:306
 msgid "Show less vocab_platform"
 msgstr "Show less Platforms"
 
@@ -1533,21 +1569,22 @@ msgstr ""
 msgid "Only sysadmin can change feature: %s"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:53
+#: ckanext/ytp/views_organization.py:54
 msgid "Unauthorized to create a group"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:74 ckanext/ytp/views_organization.py:114
-#: ckanext/ytp/views_organization.py:161 ckanext/ytp/views_organization.py:342
+#: ckanext/ytp/views_organization.py:75 ckanext/ytp/views_organization.py:104
+#: ckanext/ytp/views_organization.py:170 ckanext/ytp/views_organization.py:217
+#: ckanext/ytp/views_organization.py:398
 msgid "Group not found"
 msgstr "Category not found"
 
-#: ckanext/ytp/views_organization.py:164
+#: ckanext/ytp/views_organization.py:220
 #, python-format
 msgid "User %r not authorized to edit members of %s"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:288
+#: ckanext/ytp/views_organization.py:344
 msgid "Not authorized to see this page"
 msgstr ""
 
@@ -1588,7 +1625,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: ckanext/ytp/resources/opendata/scripts/slug-preview-ex.js:53
+#: ckanext/ytp/resources/opendata/scripts/slug-preview-ex.js:59
 #: ckanext/ytp/templates/organization/admin_list.html:50
 #: ckanext/ytp/templates/organization/bulk_process.html:47
 #: ckanext/ytp/templates/organization/members.html:35
@@ -1655,6 +1692,11 @@ msgstr ""
 msgid "Hide search filters"
 msgstr ""
 
+#: ckanext/ytp/templates/apiset/read.html:28
+#: ckanext/ytp/templates/apiset/resource_read.html:75
+msgid "Interfaces"
+msgstr ""
+
 #: ckanext/ytp/templates/apiset/resource_read.html:17
 msgid "Interface manual"
 msgstr ""
@@ -1663,30 +1705,26 @@ msgstr ""
 msgid "Additional Information"
 msgstr ""
 
-#: ckanext/ytp/templates/apiset/resource_read.html:75
-msgid "Interfaces"
-msgstr ""
-
 #: ckanext/ytp/templates/apiset/resource_read.html:105
 #: ckanext/ytp/templates/organization/read_base.html:37
-#: ckanext/ytp/templates/package/resource_read.html:64
+#: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:9
 #: ckanext/ytp/templates/package/snippets/resource_item3.html:9
 msgid "Manage"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:111
-#: ckanext/ytp/templates/package/resource_read.html:70
+#: ckanext/ytp/templates/package/resource_read.html:72
 msgid "View"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:113
-#: ckanext/ytp/templates/package/resource_read.html:72
+#: ckanext/ytp/templates/package/resource_read.html:74
 msgid "API Endpoint"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:115
-#: ckanext/ytp/templates/package/resource_read.html:74
+#: ckanext/ytp/templates/package/resource_read.html:76
 #: ckanext/ytp/templates/package/snippets/related_item.html:65
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:13
 #: ckanext/ytp/templates/package/snippets/resource_item3.html:11
@@ -1694,19 +1732,19 @@ msgid "Open"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:117
-#: ckanext/ytp/templates/package/resource_read.html:76
+#: ckanext/ytp/templates/package/resource_read.html:78
 #: ckanext/ytp/templates/package/snippets/resource_item.html:51
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:15
 msgid "Download"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:139
-#: ckanext/ytp/templates/package/resource_read.html:109
+#: ckanext/ytp/templates/package/resource_read.html:113
 msgid "From the dataset abstract"
 msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:141
-#: ckanext/ytp/templates/package/resource_read.html:111
+#: ckanext/ytp/templates/package/resource_read.html:115
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr ""
@@ -1913,7 +1951,7 @@ msgid "No organizations found"
 msgstr "No publishers found"
 
 #: ckanext/ytp/templates/organization/index.html:91
-#: ckanext/ytp/templates/package/search.html:104
+#: ckanext/ytp/templates/package/search.html:103
 msgid "Filter list"
 msgstr ""
 
@@ -1958,6 +1996,10 @@ msgstr ""
 msgid "Membership Requests"
 msgstr ""
 
+#: ckanext/ytp/templates/organization/new.html:6
+msgid "Create an Organization"
+msgstr ""
+
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
@@ -1975,7 +2017,7 @@ msgid "Last Modified"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/read.html:19
-#: ckanext/ytp/templates/package/search.html:63
+#: ckanext/ytp/templates/package/search.html:62
 #: ckanext/ytp/templates/snippets/package_item.html:45
 #: ckanext/ytp/templates/snippets/popular.html:3
 msgid "Popular"
@@ -2120,107 +2162,107 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 #, python-format
 msgid "<a href=\"%(url)s\">"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 msgid "dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:89
+#: ckanext/ytp/templates/package/resource_read.html:93
 #, python-format
 msgid "%(dataset)s"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:135
+#: ckanext/ytp/templates/package/resource_read.html:157
 #: ckanext/ytp/templates/package/snippets/resource_item.html:40
 #: ckanext/ytp/templates/snippets/datapreview_embed_dialog.html:18
 msgid "Preview"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:155
+#: ckanext/ytp/templates/package/resource_read.html:177
 msgid "There are no views created for this resource yet."
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:159
+#: ckanext/ytp/templates/package/resource_read.html:181
 msgid "Not seeing the views you were expecting?"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:161
+#: ckanext/ytp/templates/package/resource_read.html:183
 #: ckanext/ytp/templates/package/snippets/resource_view.html:26
 msgid "Click here for more information."
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:164
+#: ckanext/ytp/templates/package/resource_read.html:186
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:166
+#: ckanext/ytp/templates/package/resource_read.html:188
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:167
+#: ckanext/ytp/templates/package/resource_read.html:189
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/resource_read.html:190
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, "
 "or the data may not have been pushed to the DataStore, or the DataStore "
 "hasn't finished processing the data yet"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:184
+#: ckanext/ytp/templates/package/resource_read.html:206
 msgid "Extra information"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:188
+#: ckanext/ytp/templates/package/resource_read.html:210
 #: ckanext/ytp/templates/package/snippets/resource_form.html:31
 msgid "Format"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:189
-#: ckanext/ytp/templates/package/resource_read.html:227
-#: ckanext/ytp/templates/package/resource_read.html:231
-#: ckanext/ytp/templates/package/resource_read.html:235
+#: ckanext/ytp/templates/package/resource_read.html:211
+#: ckanext/ytp/templates/package/resource_read.html:249
+#: ckanext/ytp/templates/package/resource_read.html:253
+#: ckanext/ytp/templates/package/resource_read.html:257
 msgid "unknown"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:220
+#: ckanext/ytp/templates/package/resource_read.html:242
 msgid "Temporal Coverage"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:226
+#: ckanext/ytp/templates/package/resource_read.html:248
 msgid "Last updated"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:234
+#: ckanext/ytp/templates/package/resource_read.html:256
 msgid "sha256"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:264
+#: ckanext/ytp/templates/package/resource_read.html:286
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:111
 msgid "Stats"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:265
+#: ckanext/ytp/templates/package/resource_read.html:287
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:112
 msgid "Last 30 days, updated daily"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:268
+#: ckanext/ytp/templates/package/resource_read.html:290
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:119
 msgid "All time downloads:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:278
+#: ckanext/ytp/templates/package/resource_read.html:300
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:127
 msgid "Year"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:278
+#: ckanext/ytp/templates/package/resource_read.html:300
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:127
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:11
 msgid "Downloads"
@@ -2258,31 +2300,30 @@ msgstr ""
 msgid "Date Created Descending"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:62
-#: ckanext/ytp/templates/package/snippets/additional_info.html:12
-msgid "Source"
-msgstr ""
-
-#: ckanext/ytp/templates/package/search.html:85
+#: ckanext/ytp/templates/package/search.html:84
 msgid "API Docs"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:87
+#: ckanext/ytp/templates/package/search.html:86
 msgid "full {format} dump"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:88
+#: ckanext/ytp/templates/package/search.html:87
 #, python-format
 msgid ""
 "You can also access this registry using the %(api_link)s (see "
 "%(api_doc_link)s) or download a %(dump_link)s."
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:92
+#: ckanext/ytp/templates/package/search.html:91
 #, python-format
 msgid ""
 "You can also access this registry using the %(api_link)s (see "
 "%(api_doc_link)s)."
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/additional_info.html:12
+msgid "Source"
 msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/additional_info.html:23
@@ -2315,7 +2356,7 @@ msgid "Show more categories"
 msgstr "Show more Categories"
 
 #: ckanext/ytp/templates/package/snippets/categories.html:34
-#: ckanext/ytp/templates/snippets/facet_list.html:84
+#: ckanext/ytp/templates/snippets/facet_list.html:93
 msgid "Show more"
 msgstr "Show more"
 
@@ -2361,31 +2402,6 @@ msgstr ""
 msgid "Social"
 msgstr "Share in social media"
 
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:5
-msgid ""
-"Deleted. The dataset is only visible to logged in users of the producer "
-"organization."
-msgstr ""
-
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:8
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:18
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:28
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:34
-msgid "Edit dataset"
-msgstr ""
-
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:15
-msgid ""
-"In draft state. The dataset is only visible to logged in users of the "
-"producer organization."
-msgstr ""
-
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:25
-msgid ""
-"Private mode. The dataset is only visible to logged in users of the producer"
-" organization."
-msgstr ""
-
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:17
 #, python-format
 msgid ""
@@ -2412,6 +2428,14 @@ msgstr ""
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:43
 msgid "https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/new_data_api_button.html:7
+msgid "Loading..."
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/new_data_api_button.html:9
+msgid "Data API Instructions"
+msgstr "Open API guide"
 
 #: ckanext/ytp/templates/package/snippets/package_form.html:30
 msgid "Next: Add Data"
@@ -2488,7 +2512,7 @@ msgid "eg. January 2011 Gold Prices"
 msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/resource_form.html:26
-#: ckanext/ytp/templates/scheming/organization/about.html:14
+#: ckanext/ytp/templates/scheming/organization/about.html:16
 msgid "Description"
 msgstr ""
 
@@ -2782,7 +2806,7 @@ msgid ""
 " odt, ods, txt."
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/organization/about.html:36
+#: ckanext/ytp/templates/scheming/organization/about.html:38
 msgid "Logo of organization {org}"
 msgstr ""
 
@@ -2989,11 +3013,11 @@ msgstr ""
 msgid "Height:"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/facet_list.html:87
+#: ckanext/ytp/templates/snippets/facet_list.html:96
 msgid "Show less"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/facet_list.html:91
+#: ckanext/ytp/templates/snippets/facet_list.html:100
 msgid "There are no {facet_type} that match this search"
 msgstr ""
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -12,17 +12,18 @@
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2021
 # Daniel Vainio, 2021
-# Meeri Hakala <meeri.hakala@dvv.fi>, 2022
 # Pasi Laakso <pasi.laakso@gofore.com>, 2022
+# Meeri Hakala <meeri.hakala@dvv.fi>, 2022
+# Ville Teräväinen, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-10 09:54+0000\n"
+"POT-Creation-Date: 2022-07-13 10:02+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Pasi Laakso <pasi.laakso@gofore.com>, 2022\n"
+"Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,47 +32,47 @@ msgstr ""
 "Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/ytp/auth.py:17 ckanext/ytp/auth.py:31
+#: ckanext/ytp/auth.py:18 ckanext/ytp/auth.py:32
 msgid "Only the owner can update a related item"
 msgstr "Vain omistaja voi päivittää liittyvän median"
 
-#: ckanext/ytp/auth.py:36
+#: ckanext/ytp/auth.py:37
 msgid "You must be a sysadmin to change a related item's featured field."
 msgstr "Sinun täytyy olla sysadmin muuttaaksesi tämän kenttää"
 
-#: ckanext/ytp/auth.py:53
+#: ckanext/ytp/auth.py:54
 msgid "You must be a sysadmin to create a featured related item"
 msgstr "Sinun täytyy olla sysadmin luodaksesi tämän"
 
-#: ckanext/ytp/auth.py:61 ckanext/ytp/auth.py:64
+#: ckanext/ytp/auth.py:62 ckanext/ytp/auth.py:65
 msgid "You must be logged in to add a related item"
 msgstr "Sinun täytyy olla kirjautunut lisätäksesi liittyvän median"
 
-#: ckanext/ytp/auth.py:71 ckanext/ytp/auth.py:76
+#: ckanext/ytp/auth.py:72 ckanext/ytp/auth.py:77
 #, python-format
 msgid "User %s not authorized to create public organizations"
 msgstr "Käyttäjällä %s ei ole oikeuksia luoda julkisia organisaatioita"
 
-#: ckanext/ytp/auth.py:89
+#: ckanext/ytp/auth.py:90
 msgid "Only registered users can create organizations"
 msgstr "Vain rekisteröityneet käyttäjät saavat luoda organisaatioita"
 
-#: ckanext/ytp/auth.py:104 ckanext/ytp/validators.py:468
+#: ckanext/ytp/auth.py:105 ckanext/ytp/validators.py:468
 #, python-format
 msgid "User %s is not administrator in the selected parent organization"
 msgstr "Käyttäjä %s ei ole ylläpitäjä valitussa yläorganisaatiossa"
 
-#: ckanext/ytp/auth.py:113
+#: ckanext/ytp/auth.py:114
 #, python-format
 msgid "User %s not authorized to create organizations"
 msgstr "Käyttäjällä %s ei ole oikeuksia luoda organisaatioita"
 
-#: ckanext/ytp/auth.py:133
+#: ckanext/ytp/auth.py:136
 msgid "Cannot modify dataset because of organization policy"
 msgstr "Tietoaineiston muokkaaminen on vastoin organisaation käytäntöjä"
 
-#: ckanext/ytp/auth.py:141 ckanext/ytp/views_organization.py:219
-#: ckanext/ytp/views_organization.py:267
+#: ckanext/ytp/auth.py:144 ckanext/ytp/views_organization.py:275
+#: ckanext/ytp/views_organization.py:323
 msgid "Only system administrators are allowed to view user list."
 msgstr "Vain järjestelmän ylläpitäjä saa katsella käyttäjälistaa."
 
@@ -177,11 +178,11 @@ msgid "Related item was successfully updated"
 msgstr "Tähän liittyvä kohde päivitettiin onnistuneesti"
 
 #: ckanext/ytp/controller.py:419 ckanext/ytp/controller.py:691
-#: ckanext/ytp/views_organization.py:76
+#: ckanext/ytp/views_organization.py:77
 msgid "Integrity Error"
 msgstr "Eheysvirhe"
 
-#: ckanext/ytp/controller.py:439 ckanext/ytp/templates/package/search.html:84
+#: ckanext/ytp/controller.py:439 ckanext/ytp/templates/package/search.html:83
 #: ckanext/ytp/templates/package/snippets/related_item.html:21
 msgid "API"
 msgstr "API"
@@ -255,11 +256,11 @@ msgstr ""
 msgid "Date format incorrect"
 msgstr "Päivämäärän muoto väärä"
 
-#: ckanext/ytp/helpers.py:98 ckanext/ytp/plugin.py:322
+#: ckanext/ytp/helpers.py:103 ckanext/ytp/plugin.py:321
 msgid "Unnamed resource"
 msgstr "Nimetön data-aineisto"
 
-#: ckanext/ytp/helpers.py:578
+#: ckanext/ytp/helpers.py:583
 msgid "-"
 msgstr ""
 
@@ -326,7 +327,7 @@ msgstr "Poista käyttäjätili"
 msgid "Users"
 msgstr "Käyttäjät"
 
-#: ckanext/ytp/menu.py:155 ckanext/ytp/plugin.py:270
+#: ckanext/ytp/menu.py:155
 #: ckanext/ytp/templates/organization/admin_list.html:31
 #: ckanext/ytp/templates/organization/edit.html:4
 #: ckanext/ytp/templates/organization/index.html:13
@@ -357,43 +358,55 @@ msgstr "Julkaise avointa dataa"
 msgid "Publish Data"
 msgstr "Julkaise dataa"
 
-#: ckanext/ytp/plugin.py:266
+#: ckanext/ytp/plugin.py:265
 msgid "International Benchmarks"
 msgstr "Kansainväliset vertailut"
 
-#: ckanext/ytp/plugin.py:267 ckanext/ytp/plugin.py:281
+#: ckanext/ytp/plugin.py:266 ckanext/ytp/translations.py:68
+msgid "Geographical coverage"
+msgstr "Maantieteellinen kattavuus"
+
+#: ckanext/ytp/plugin.py:267 ckanext/ytp/plugin.py:280
 msgid "Collection Types"
 msgstr "Tietoaineisto"
 
-#: ckanext/ytp/plugin.py:268
-msgid "Popular Tags"
-msgstr "Suositut avainsanat"
-
-#: ckanext/ytp/plugin.py:269 ckanext/ytp/plugin.py:283
-msgid "Content Types"
-msgstr "Sisältötyyppi"
-
-#: ckanext/ytp/plugin.py:271 ckanext/ytp/plugin.py:284
-#: ckanext/ytp/translations.py:35
-msgid "Formats"
-msgstr "Tiedostomuoto"
-
-#: ckanext/ytp/plugin.py:273
-msgid "Sources"
-msgstr "Lähde"
-
-#: ckanext/ytp/plugin.py:274
-msgid "Licenses"
-msgstr "Lisenssi"
-
-#: ckanext/ytp/plugin.py:282
+#: ckanext/ytp/plugin.py:268 ckanext/ytp/plugin.py:281
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:14
 msgid "Tags"
 msgstr "Avainsanat"
 
-#: ckanext/ytp/plugin.py:322
+#: ckanext/ytp/plugin.py:269
+#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
+#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
+#: ckanext/ytp/templates/snippets/organization.html:21
+#: ckanext/ytp/translations.py:36
+msgid "Organization"
+msgstr "Tuottaja"
+
+#: ckanext/ytp/plugin.py:270 ckanext/ytp/plugin.py:283
+#: ckanext/ytp/translations.py:35
+msgid "Formats"
+msgstr "Tiedostomuoto"
+
+#: ckanext/ytp/plugin.py:271
+msgid "Licenses"
+msgstr "Lisenssi"
+
+#: ckanext/ytp/plugin.py:272
+msgid "Category"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:273 ckanext/ytp/translations.py:87
+msgid "Producer type"
+msgstr "Alueellinen kattavuus / Tuottajatyyppi"
+
+#: ckanext/ytp/plugin.py:282
+msgid "Content Types"
+msgstr "Sisältötyyppi"
+
+#: ckanext/ytp/plugin.py:321
 #: ckanext/ytp/templates/package/snippets/additional_info.html:2
-#: ckanext/ytp/templates/scheming/organization/about.html:18
+#: ckanext/ytp/templates/scheming/organization/about.html:20
 msgid "Additional Info"
 msgstr "Lisätiedot"
 
@@ -457,7 +470,7 @@ msgstr "Ulkoinen"
 msgid "Internal"
 msgstr "Sisäinen"
 
-#: ckanext/ytp/templates/package/resource_read.html:230
+#: ckanext/ytp/templates/package/resource_read.html:252
 #: ckanext/ytp/templates/package/snippets/additional_info.html:68
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:8
 #: ckanext/ytp/translations.py:28
@@ -488,13 +501,6 @@ msgstr "Logo tai kuvituskuva"
 #: ckanext/ytp/translations.py:34
 msgid "Size"
 msgstr "Tiedostokoko"
-
-#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
-#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
-#: ckanext/ytp/templates/snippets/organization.html:21
-#: ckanext/ytp/translations.py:36
-msgid "Organization"
-msgstr "Tuottaja"
 
 #: ckanext/ytp/translations.py:37
 msgid "Key"
@@ -623,10 +629,6 @@ msgstr "esim. joe@example.com"
 msgid "Copyright notice"
 msgstr "Tekijänoikeusilmoitus"
 
-#: ckanext/ytp/translations.py:68
-msgid "Geographical coverage"
-msgstr "Maantieteellinen kattavuus"
-
 #: ckanext/ytp/translations.py:69
 msgid "Select the municipalities from which the dataset contains data."
 msgstr "Valitse kunnat joita tietoaineisto koskee"
@@ -699,10 +701,6 @@ msgstr "Sovelluksen nimi"
 #: ckanext/ytp/translations.py:86
 msgid "Categories"
 msgstr "Kategoriat"
-
-#: ckanext/ytp/translations.py:87
-msgid "Producer type"
-msgstr "Alueellinen kattavuus / Tuottajatyyppi"
 
 #: ckanext/ytp/translations.py:88
 msgid "Public administration organization"
@@ -1129,7 +1127,7 @@ msgstr ""
 
 #: ckanext/ytp/translations.py:201
 msgid "Select at least one category."
-msgstr "Valitse listasta yksi tai useampi sovellusta kuvaava kategoria."
+msgstr "Valitse yksi tai useampi tietoaineistoa kuvaava kategoria."
 
 #: ckanext/ytp/translations.py:202
 msgid "Dataset additional information"
@@ -1137,7 +1135,7 @@ msgstr "Tietoaineiston muut tiedot"
 
 #: ckanext/ytp/translations.py:203
 msgid "Dataset visibility"
-msgstr "Tietoaineiston näkyvyys"
+msgstr "Tietoaineiston näkyvyys avoindata.fi:ssä"
 
 #: ckanext/ytp/translations.py:204
 msgid ""
@@ -1225,11 +1223,53 @@ msgstr ""
 msgid "e.g. avoindata@dvv.fi"
 msgstr "esim. avoindata@dvv.fi"
 
+#: ckanext/ytp/translations.py:219
+msgid ""
+"Deleted. The dataset is only visible to logged in users of the producer "
+"organization."
+msgstr ""
+"Tietoaineisto on poistettu. Se näkyy vain tietoaineiston julkaisseen "
+"organisaation jäsenille. "
+
+#: ckanext/ytp/translations.py:220
+msgid ""
+"In draft state. The dataset is only visible to logged in users of the "
+"producer organization."
+msgstr ""
+"Tietoaineisto on luonnostilassa. Se näkyy vain tietoaineiston julkaisseen "
+"organisaation jäsenille. "
+
 #: ckanext/ytp/translations.py:221
+msgid ""
+"Private mode. The dataset is only visible to logged in users of the producer"
+" organization."
+msgstr ""
+"Tietoaineisto on yksityinen. Se näkyy vain tietoaineiston julkaisseen "
+"organisaation jäsenille. "
+
+#: ckanext/ytp/translations.py:222
+msgid ""
+"Deleted. The apiset is only visible to logged in users of the producer "
+"organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:223
+msgid ""
+"In draft state. The apiset is only visible to logged in users of the "
+"producer organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:224
+msgid ""
+"Private mode. The apiset is only visible to logged in users of the producer "
+"organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:227
 msgid "Data resource title"
 msgstr "Data-aineiston nimi"
 
-#: ckanext/ytp/translations.py:222
+#: ckanext/ytp/translations.py:228
 msgid ""
 "Write a short and descriptive name for the data resource. If the data covers"
 " a specific time frame, mention that in the name."
@@ -1237,15 +1277,15 @@ msgstr ""
 "Kirjoita lyhyt ja kuvaava nimi data-aineistolle. Jos data kattaa vain tietyn"
 " aikavälin, mainitse se nimessä."
 
-#: ckanext/ytp/translations.py:223
+#: ckanext/ytp/translations.py:229
 msgid "e.g. Most popular Finnish first names 2019"
 msgstr "esim. Suosituimmat suomalaiset etunimet 2019"
 
-#: ckanext/ytp/translations.py:224
+#: ckanext/ytp/translations.py:230
 msgid "Resource *"
 msgstr "Data-aineisto *"
 
-#: ckanext/ytp/translations.py:225
+#: ckanext/ytp/translations.py:231
 msgid ""
 "Add the data resource by uploading a file or adding a link to the "
 "data.<br>Select or drag the files here.<br>The maximum file size is 5 Gb. "
@@ -1257,15 +1297,15 @@ msgstr ""
 "ovat mm. pdf, jpg, jpeg, png, doc, docx, xls, xlsx, csv, ppt, pptx, odt, "
 "ods, txt."
 
-#: ckanext/ytp/translations.py:226
+#: ckanext/ytp/translations.py:232
 msgid "Data resource description"
 msgstr "Data-aineiston kuvaus"
 
-#: ckanext/ytp/translations.py:227
+#: ckanext/ytp/translations.py:233
 msgid "Write a description for the resource"
 msgstr "Kirjoita kuvaus data-aineistolle"
 
-#: ckanext/ytp/translations.py:228
+#: ckanext/ytp/translations.py:234
 msgid ""
 "Describe the data clearly and concisely. Use as confining terms as possible "
 "to make it easier to find and understand the data."
@@ -1273,15 +1313,15 @@ msgstr ""
 "Tiivis ja helppotajuinen kuvaus data-aineistosta. Käytä mahdollisimman "
 "rajaavia termejä helpottamaan datan ymmärtämistä."
 
-#: ckanext/ytp/translations.py:229
+#: ckanext/ytp/translations.py:235
 msgid "Additional information"
 msgstr "Lisätiedot"
 
-#: ckanext/ytp/translations.py:230
+#: ckanext/ytp/translations.py:236
 msgid "Data status"
 msgstr "Aineiston tila"
 
-#: ckanext/ytp/translations.py:231
+#: ckanext/ytp/translations.py:237
 msgid ""
 "Define a state for the data. This is recommended especially if your dataset "
 "has data resources from multiple years."
@@ -1289,11 +1329,11 @@ msgstr ""
 "Voit määritellä data-aineistolle tilan. Tämä on suositeltavaa erityisesti "
 "jos tietoaineistollasi on data-aineistoja useilta eri vuosilta."
 
-#: ckanext/ytp/translations.py:232
+#: ckanext/ytp/translations.py:238
 msgid "Coordinate system"
 msgstr "Sijaintikoordinaattien muoto"
 
-#: ckanext/ytp/translations.py:233
+#: ckanext/ytp/translations.py:239
 msgid ""
 "If your data includes geographic information, specify the coordinate system "
 "it uses."
@@ -1301,11 +1341,11 @@ msgstr ""
 "Kerro missä muodossa karttamuotoisen aineiston koordinaatit ovat. Esim. "
 "koordinaatisto, jossa sijaintidata tarjotaan."
 
-#: ckanext/ytp/translations.py:234
+#: ckanext/ytp/translations.py:240
 msgid "e.g. WGS84 (World Geodetic System 1984)"
 msgstr "esim. WGS84 (World Geodetic System 1984)"
 
-#: ckanext/ytp/translations.py:235
+#: ckanext/ytp/translations.py:241
 msgid ""
 "Select the time frame by which the data is separated. For example, does the "
 "resource include data from every week or month."
@@ -1313,223 +1353,225 @@ msgstr ""
 "Kerro, kuinka tarkasti data on eroteltu aineistossa. Esimerkiksi sisältääkö "
 "aineisto dataa joka viikolta tai kuukaudelta."
 
-#: ckanext/ytp/translations.py:236
+#: ckanext/ytp/translations.py:242
 msgid "e.g. a month"
 msgstr "esim. kuukausi"
 
-#: ckanext/ytp/translations.py:237
+#: ckanext/ytp/translations.py:243
 msgid "Time Frame"
 msgstr "Ajallinen kattavuus"
 
-#: ckanext/ytp/translations.py:238
+#: ckanext/ytp/translations.py:244
 msgid "Start date"
 msgstr "Alkuajankohta"
 
-#: ckanext/ytp/translations.py:239
+#: ckanext/ytp/translations.py:245
 msgid "End date"
 msgstr "Loppuajankohta"
 
-#: ckanext/ytp/translations.py:242
+#: ckanext/ytp/translations.py:248
 msgid "Producer name"
 msgstr "Tuottajan nimi"
 
-#: ckanext/ytp/translations.py:243
+#: ckanext/ytp/translations.py:249
 msgid "Producer description"
 msgstr "Tuottajan kuvaus"
 
-#: ckanext/ytp/translations.py:244
+#: ckanext/ytp/translations.py:250
 msgid "Common, compact and plain description about producer"
-msgstr "Yleinen, tiivis ja helppotajuinen kuvaus tuottajasta. "
+msgstr ""
+"Kerro, mitä organisaatiosi tekee ja millaisia palveluja sekä millaista dataa"
+" se tarjoaa. "
 
-#: ckanext/ytp/translations.py:245
+#: ckanext/ytp/translations.py:251
 msgid "Other information"
 msgstr "Muut tiedot"
 
-#: ckanext/ytp/translations.py:248
+#: ckanext/ytp/translations.py:254
 msgid "cc-by"
 msgstr "Creative Commons Attribution"
 
-#: ckanext/ytp/translations.py:249
+#: ckanext/ytp/translations.py:255
 msgid "cc-by-4-fi"
 msgstr " Creative Commons Nimeä 4.0"
 
-#: ckanext/ytp/translations.py:250
+#: ckanext/ytp/translations.py:256
 msgid "cc-by-4.0"
 msgstr " Creative Commons Nimeä 4.0"
 
-#: ckanext/ytp/translations.py:251
+#: ckanext/ytp/translations.py:257
 msgid "cc-by-sa"
 msgstr "Creative Commons Attribution Share-Alike"
 
-#: ckanext/ytp/translations.py:252
+#: ckanext/ytp/translations.py:258
 msgid "cc-by-sa-1-fi"
 msgstr "Creative Commons Nime\\xe4-Tarttuva 1.0 Suomi CC BY-SA 1.0"
 
-#: ckanext/ytp/translations.py:253
+#: ckanext/ytp/translations.py:259
 msgid "cc-nc"
 msgstr "Creative Commons Non-Commercial Any"
 
-#: ckanext/ytp/translations.py:254
+#: ckanext/ytp/translations.py:260
 msgid "cc-zero"
 msgstr "Creative Commons CCZero"
 
-#: ckanext/ytp/translations.py:255
+#: ckanext/ytp/translations.py:261
 msgid "cc-zero-1.0"
 msgstr "Creative Commons CCZero 1.0"
 
-#: ckanext/ytp/translations.py:256
+#: ckanext/ytp/translations.py:262
 msgid "gfdl"
 msgstr "GNU Free Documentation License"
 
-#: ckanext/ytp/translations.py:257
+#: ckanext/ytp/translations.py:263
 msgid "helsinkikanava-opendata-tos"
 msgstr " Helsinkikanava Open Data käyttöehdot"
 
-#: ckanext/ytp/translations.py:258
+#: ckanext/ytp/translations.py:264
 msgid "hri-tietoaineistot-lisenssi-nimea"
 msgstr " HRI - tietoaineistojen lisenssi - nimeä"
 
-#: ckanext/ytp/translations.py:259
+#: ckanext/ytp/translations.py:265
 msgid "ilmoitettumuualla"
 msgstr " Lisenssi ilmoitettu tietoaineiston ylläpitäjän palvelussa"
 
-#: ckanext/ytp/translations.py:260
+#: ckanext/ytp/translations.py:266
 msgid "kmo-aluejakorajat"
 msgstr " KMO aluejakorajojen vektoriaineistojen käyttöehdot"
 
-#: ckanext/ytp/translations.py:261
+#: ckanext/ytp/translations.py:267
 msgid "notspecified"
 msgstr " Lisenssiä ei ole määritelty"
 
-#: ckanext/ytp/translations.py:262
+#: ckanext/ytp/translations.py:268
 msgid "odc-by"
 msgstr "Open Data Commons Attribution License"
 
-#: ckanext/ytp/translations.py:263
+#: ckanext/ytp/translations.py:269
 msgid "odc-odbl"
 msgstr "Open Data Commons Open Database License ODbL"
 
-#: ckanext/ytp/translations.py:264
+#: ckanext/ytp/translations.py:270
 msgid "odc-pddl"
 msgstr "Open Data Commons Public Domain Dedication and Licence PDDL"
 
-#: ckanext/ytp/translations.py:265
+#: ckanext/ytp/translations.py:271
 msgid "other"
 msgstr " Muu"
 
-#: ckanext/ytp/translations.py:266
+#: ckanext/ytp/translations.py:272
 msgid "other-at"
 msgstr "Muu (Attribution)"
 
-#: ckanext/ytp/translations.py:267
+#: ckanext/ytp/translations.py:273
 msgid "other-closed"
 msgstr "Muu (Not Open)"
 
-#: ckanext/ytp/translations.py:268
+#: ckanext/ytp/translations.py:274
 msgid "other-nc"
 msgstr " Muu (Non-Commercial)"
 
-#: ckanext/ytp/translations.py:269
+#: ckanext/ytp/translations.py:275
 msgid "other-open"
 msgstr " Muu (avoin)"
 
-#: ckanext/ytp/translations.py:270
+#: ckanext/ytp/translations.py:276
 msgid "other-pd"
 msgstr " Muu (Public Domain)"
 
-#: ckanext/ytp/translations.py:271
+#: ckanext/ytp/translations.py:277
 msgid "uk-ogl"
 msgstr "UK Open Government Licence OGL"
 
-#: ckanext/ytp/translations.py:274
+#: ckanext/ytp/translations.py:280
 msgid "Platforms"
 msgstr "Käyttöympäristö (alusta)"
 
-#: ckanext/ytp/translations.py:277
+#: ckanext/ytp/translations.py:283
 msgid "Show more collection_type"
 msgstr "Näytä enemmän Tietoaineistoja"
 
-#: ckanext/ytp/translations.py:278
+#: ckanext/ytp/translations.py:284
 msgid "Show more vocab_international_benchmarks"
 msgstr "Näytä enemmän Kansainvälisiä Vertailuja"
 
-#: ckanext/ytp/translations.py:279
+#: ckanext/ytp/translations.py:285
 msgid "Show more vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:280
+#: ckanext/ytp/translations.py:286
 msgid "Show more vocab_keywords_fi"
 msgstr "Näytä enemmän Avainsanoja"
 
-#: ckanext/ytp/translations.py:281
+#: ckanext/ytp/translations.py:287
 msgid "Show more vocab_keywords_sv"
 msgstr ""
 
-#: ckanext/ytp/translations.py:282
+#: ckanext/ytp/translations.py:288
 msgid "Show more organization"
 msgstr "Näytä enemmän Tuottajia"
 
-#: ckanext/ytp/translations.py:283
+#: ckanext/ytp/translations.py:289
 msgid "Show more res_format"
 msgstr "Näytä enemmän Tiedostomuotoja"
 
-#: ckanext/ytp/translations.py:284
+#: ckanext/ytp/translations.py:290
 msgid "Show more source"
 msgstr "Näytä enemmän Lähteitä"
 
-#: ckanext/ytp/translations.py:285
+#: ckanext/ytp/translations.py:291
 msgid "Show more license_id"
 msgstr "Näytä enemmän Lisenssejä"
 
-#: ckanext/ytp/translations.py:286
+#: ckanext/ytp/translations.py:292
 msgid "Show more groups"
 msgstr "Näytä enemmän Kategorioita"
 
-#: ckanext/ytp/translations.py:287
+#: ckanext/ytp/translations.py:293
 msgid "Show more vocab_platform"
 msgstr "Näytä enemmän Käyttöympäristöjä"
 
-#: ckanext/ytp/translations.py:290
+#: ckanext/ytp/translations.py:296
 msgid "Show less collection_type"
 msgstr "Näytä vähemmän Tietoaineistoja"
 
-#: ckanext/ytp/translations.py:291
+#: ckanext/ytp/translations.py:297
 msgid "Show less vocab_international_benchmarks"
 msgstr "Näytä vähemmän Kansainvälisiä Vertailuja"
 
-#: ckanext/ytp/translations.py:292
+#: ckanext/ytp/translations.py:298
 msgid "Show less vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:293
+#: ckanext/ytp/translations.py:299
 msgid "Show less vocab_keywords_fi"
 msgstr "Näytä vähemmän Avainsanoja"
 
-#: ckanext/ytp/translations.py:294
+#: ckanext/ytp/translations.py:300
 msgid "Show less vocab_keywords_sv"
 msgstr ""
 
-#: ckanext/ytp/translations.py:295
+#: ckanext/ytp/translations.py:301
 msgid "Show less organization"
 msgstr "Näytä vähemmän Tuottajia"
 
-#: ckanext/ytp/translations.py:296
+#: ckanext/ytp/translations.py:302
 msgid "Show less res_format"
 msgstr "Näytä vähemmän Tiedostomuotoja"
 
-#: ckanext/ytp/translations.py:297
+#: ckanext/ytp/translations.py:303
 msgid "Show less source"
 msgstr "Näytä vähemmän Lähteitä"
 
-#: ckanext/ytp/translations.py:298
+#: ckanext/ytp/translations.py:304
 msgid "Show less license_id"
 msgstr "Näytä vähemmän Lisenssejä"
 
-#: ckanext/ytp/translations.py:299
+#: ckanext/ytp/translations.py:305
 msgid "Show less groups"
 msgstr "Näytä vähemmän Kategorioita"
 
-#: ckanext/ytp/translations.py:300
+#: ckanext/ytp/translations.py:306
 msgid "Show less vocab_platform"
 msgstr "Näytä vähemmän Käyttöympäristöjä"
 
@@ -1585,21 +1627,22 @@ msgstr "Loppupäivä on ennen alkupäivää"
 msgid "Only sysadmin can change feature: %s"
 msgstr "Vain järjestelmän ylläpitäjät voivat muuttaa ominaisuutta: %s"
 
-#: ckanext/ytp/views_organization.py:53
+#: ckanext/ytp/views_organization.py:54
 msgid "Unauthorized to create a group"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:74 ckanext/ytp/views_organization.py:114
-#: ckanext/ytp/views_organization.py:161 ckanext/ytp/views_organization.py:342
+#: ckanext/ytp/views_organization.py:75 ckanext/ytp/views_organization.py:104
+#: ckanext/ytp/views_organization.py:170 ckanext/ytp/views_organization.py:217
+#: ckanext/ytp/views_organization.py:398
 msgid "Group not found"
 msgstr "Kategoriaa ei löydy"
 
-#: ckanext/ytp/views_organization.py:164
+#: ckanext/ytp/views_organization.py:220
 #, python-format
 msgid "User %r not authorized to edit members of %s"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:288
+#: ckanext/ytp/views_organization.py:344
 msgid "Not authorized to see this page"
 msgstr "Ei oikeuksia nähdä tätä sivua"
 
@@ -1640,7 +1683,7 @@ msgstr "Peruuta"
 msgid "Remove"
 msgstr "Poista"
 
-#: ckanext/ytp/resources/opendata/scripts/slug-preview-ex.js:53
+#: ckanext/ytp/resources/opendata/scripts/slug-preview-ex.js:59
 #: ckanext/ytp/templates/organization/admin_list.html:50
 #: ckanext/ytp/templates/organization/bulk_process.html:47
 #: ckanext/ytp/templates/organization/members.html:35
@@ -1707,6 +1750,11 @@ msgstr "Anna palautetta"
 msgid "Hide search filters"
 msgstr "Piilota suodattimet"
 
+#: ckanext/ytp/templates/apiset/read.html:28
+#: ckanext/ytp/templates/apiset/resource_read.html:75
+msgid "Interfaces"
+msgstr ""
+
 #: ckanext/ytp/templates/apiset/resource_read.html:17
 msgid "Interface manual"
 msgstr ""
@@ -1715,30 +1763,26 @@ msgstr ""
 msgid "Additional Information"
 msgstr "Lisätiedot"
 
-#: ckanext/ytp/templates/apiset/resource_read.html:75
-msgid "Interfaces"
-msgstr ""
-
 #: ckanext/ytp/templates/apiset/resource_read.html:105
 #: ckanext/ytp/templates/organization/read_base.html:37
-#: ckanext/ytp/templates/package/resource_read.html:64
+#: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:9
 #: ckanext/ytp/templates/package/snippets/resource_item3.html:9
 msgid "Manage"
 msgstr "Muokkaa"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:111
-#: ckanext/ytp/templates/package/resource_read.html:70
+#: ckanext/ytp/templates/package/resource_read.html:72
 msgid "View"
 msgstr "Katsele"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:113
-#: ckanext/ytp/templates/package/resource_read.html:72
+#: ckanext/ytp/templates/package/resource_read.html:74
 msgid "API Endpoint"
 msgstr "API-päätepiste"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:115
-#: ckanext/ytp/templates/package/resource_read.html:74
+#: ckanext/ytp/templates/package/resource_read.html:76
 #: ckanext/ytp/templates/package/snippets/related_item.html:65
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:13
 #: ckanext/ytp/templates/package/snippets/resource_item3.html:11
@@ -1746,19 +1790,19 @@ msgid "Open"
 msgstr "Avaa"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:117
-#: ckanext/ytp/templates/package/resource_read.html:76
+#: ckanext/ytp/templates/package/resource_read.html:78
 #: ckanext/ytp/templates/package/snippets/resource_item.html:51
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:15
 msgid "Download"
 msgstr "Lataa"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:139
-#: ckanext/ytp/templates/package/resource_read.html:109
+#: ckanext/ytp/templates/package/resource_read.html:113
 msgid "From the dataset abstract"
 msgstr "Tietoaineiston yhteenvedosta"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:141
-#: ckanext/ytp/templates/package/resource_read.html:111
+#: ckanext/ytp/templates/package/resource_read.html:115
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr "Lähde: <a href=\"%(url)s\">%(dataset)s</a>"
@@ -1966,7 +2010,7 @@ msgid "No organizations found"
 msgstr "Tuottajia ei löytynyt"
 
 #: ckanext/ytp/templates/organization/index.html:91
-#: ckanext/ytp/templates/package/search.html:104
+#: ckanext/ytp/templates/package/search.html:103
 msgid "Filter list"
 msgstr "Rajaa listaa"
 
@@ -2011,6 +2055,10 @@ msgstr "Jäsenet"
 msgid "Membership Requests"
 msgstr "Jäsenhakemukset"
 
+#: ckanext/ytp/templates/organization/new.html:6
+msgid "Create an Organization"
+msgstr ""
+
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
@@ -2028,7 +2076,7 @@ msgid "Last Modified"
 msgstr "Viimeksi muokattu"
 
 #: ckanext/ytp/templates/organization/read.html:19
-#: ckanext/ytp/templates/package/search.html:63
+#: ckanext/ytp/templates/package/search.html:62
 #: ckanext/ytp/templates/snippets/package_item.html:45
 #: ckanext/ytp/templates/snippets/popular.html:3
 msgid "Popular"
@@ -2177,107 +2225,107 @@ msgstr "DataStore"
 msgid "Views"
 msgstr "Esikatselunäkymät"
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 #, python-format
 msgid "<a href=\"%(url)s\">"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 msgid "dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:89
+#: ckanext/ytp/templates/package/resource_read.html:93
 #, python-format
 msgid "%(dataset)s"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:135
+#: ckanext/ytp/templates/package/resource_read.html:157
 #: ckanext/ytp/templates/package/snippets/resource_item.html:40
 #: ckanext/ytp/templates/snippets/datapreview_embed_dialog.html:18
 msgid "Preview"
 msgstr "Esikatselu"
 
-#: ckanext/ytp/templates/package/resource_read.html:155
+#: ckanext/ytp/templates/package/resource_read.html:177
 msgid "There are no views created for this resource yet."
 msgstr "Data-aineistolle ei ole lisätty esikatselunäkymiä."
 
-#: ckanext/ytp/templates/package/resource_read.html:159
+#: ckanext/ytp/templates/package/resource_read.html:181
 msgid "Not seeing the views you were expecting?"
 msgstr "Puuttuvatko odottamasi esikatselunäkymät?"
 
-#: ckanext/ytp/templates/package/resource_read.html:161
+#: ckanext/ytp/templates/package/resource_read.html:183
 #: ckanext/ytp/templates/package/snippets/resource_view.html:26
 msgid "Click here for more information."
 msgstr "Klikkaa tästä saadaksesi lisätietoa."
 
-#: ckanext/ytp/templates/package/resource_read.html:164
+#: ckanext/ytp/templates/package/resource_read.html:186
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr "Mahdollisia syitä puuttuville esikatselunäkymille:"
 
-#: ckanext/ytp/templates/package/resource_read.html:166
+#: ckanext/ytp/templates/package/resource_read.html:188
 msgid "No view has been created that is suitable for this resource"
 msgstr "Tälle data-aineistolle ei ole luotu esikatselunäkymiä. "
 
-#: ckanext/ytp/templates/package/resource_read.html:167
+#: ckanext/ytp/templates/package/resource_read.html:189
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/resource_read.html:190
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, "
 "or the data may not have been pushed to the DataStore, or the DataStore "
 "hasn't finished processing the data yet"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:184
+#: ckanext/ytp/templates/package/resource_read.html:206
 msgid "Extra information"
 msgstr "Lisätietoja"
 
-#: ckanext/ytp/templates/package/resource_read.html:188
+#: ckanext/ytp/templates/package/resource_read.html:210
 #: ckanext/ytp/templates/package/snippets/resource_form.html:31
 msgid "Format"
 msgstr "Muoto"
 
-#: ckanext/ytp/templates/package/resource_read.html:189
-#: ckanext/ytp/templates/package/resource_read.html:227
-#: ckanext/ytp/templates/package/resource_read.html:231
-#: ckanext/ytp/templates/package/resource_read.html:235
+#: ckanext/ytp/templates/package/resource_read.html:211
+#: ckanext/ytp/templates/package/resource_read.html:249
+#: ckanext/ytp/templates/package/resource_read.html:253
+#: ckanext/ytp/templates/package/resource_read.html:257
 msgid "unknown"
 msgstr "tuntematon"
 
-#: ckanext/ytp/templates/package/resource_read.html:220
+#: ckanext/ytp/templates/package/resource_read.html:242
 msgid "Temporal Coverage"
 msgstr "Katettu ajanjakso"
 
-#: ckanext/ytp/templates/package/resource_read.html:226
+#: ckanext/ytp/templates/package/resource_read.html:248
 msgid "Last updated"
 msgstr "Viimeisin päivitys"
 
-#: ckanext/ytp/templates/package/resource_read.html:234
+#: ckanext/ytp/templates/package/resource_read.html:256
 msgid "sha256"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:264
+#: ckanext/ytp/templates/package/resource_read.html:286
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:111
 msgid "Stats"
 msgstr "Tilastot"
 
-#: ckanext/ytp/templates/package/resource_read.html:265
+#: ckanext/ytp/templates/package/resource_read.html:287
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:112
 msgid "Last 30 days, updated daily"
 msgstr "Viimeiset 30 päivää, päivitetään päivittäin"
 
-#: ckanext/ytp/templates/package/resource_read.html:268
+#: ckanext/ytp/templates/package/resource_read.html:290
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:119
 msgid "All time downloads:"
 msgstr "Latauksia kaikkiaan:"
 
-#: ckanext/ytp/templates/package/resource_read.html:278
+#: ckanext/ytp/templates/package/resource_read.html:300
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:127
 msgid "Year"
 msgstr "Vuosi"
 
-#: ckanext/ytp/templates/package/resource_read.html:278
+#: ckanext/ytp/templates/package/resource_read.html:300
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:127
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:11
 msgid "Downloads"
@@ -2322,32 +2370,31 @@ msgstr "Luomispäivän mukaan nousevasti"
 msgid "Date Created Descending"
 msgstr "Luomispäivän mukaan laskevasti"
 
-#: ckanext/ytp/templates/package/search.html:62
-#: ckanext/ytp/templates/package/snippets/additional_info.html:12
-msgid "Source"
-msgstr "Lähde"
-
-#: ckanext/ytp/templates/package/search.html:85
+#: ckanext/ytp/templates/package/search.html:84
 msgid "API Docs"
 msgstr "API-dokumentaatio"
 
-#: ckanext/ytp/templates/package/search.html:87
+#: ckanext/ytp/templates/package/search.html:86
 msgid "full {format} dump"
 msgstr "täysi {format} dumppi"
 
-#: ckanext/ytp/templates/package/search.html:88
+#: ckanext/ytp/templates/package/search.html:87
 #, python-format
 msgid ""
 "You can also access this registry using the %(api_link)s (see "
 "%(api_doc_link)s) or download a %(dump_link)s."
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:92
+#: ckanext/ytp/templates/package/search.html:91
 #, python-format
 msgid ""
 "You can also access this registry using the %(api_link)s (see "
 "%(api_doc_link)s)."
 msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/additional_info.html:12
+msgid "Source"
+msgstr "Lähde"
 
 #: ckanext/ytp/templates/package/snippets/additional_info.html:23
 #: ckanext/ytp/templates/package/snippets/additional_info.html:28
@@ -2379,7 +2426,7 @@ msgid "Show more categories"
 msgstr "Näytä lisää kategorioita"
 
 #: ckanext/ytp/templates/package/snippets/categories.html:34
-#: ckanext/ytp/templates/snippets/facet_list.html:84
+#: ckanext/ytp/templates/snippets/facet_list.html:93
 msgid "Show more"
 msgstr "Näytä lisää"
 
@@ -2425,37 +2472,6 @@ msgstr "Käyttösovellukset"
 msgid "Social"
 msgstr "Jaa sosiaalisessa mediassa"
 
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:5
-msgid ""
-"Deleted. The dataset is only visible to logged in users of the producer "
-"organization."
-msgstr ""
-"Tietoaineisto on poistettu. Se näkyy vain tietoaineiston julkaisseen "
-"organisaation jäsenille. "
-
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:8
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:18
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:28
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:34
-msgid "Edit dataset"
-msgstr "Muokkaa tietoaineistoa"
-
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:15
-msgid ""
-"In draft state. The dataset is only visible to logged in users of the "
-"producer organization."
-msgstr ""
-"Tietoaineisto on luonnostilassa. Se näkyy vain tietoaineiston julkaisseen "
-"organisaation jäsenille. "
-
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:25
-msgid ""
-"Private mode. The dataset is only visible to logged in users of the producer"
-" organization."
-msgstr ""
-"Tietoaineisto on yksityinen. Se näkyy vain tietoaineiston julkaisseen "
-"organisaation jäsenille. "
-
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:17
 #, python-format
 msgid ""
@@ -2491,6 +2507,14 @@ msgstr ""
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:43
 msgid "https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/new_data_api_button.html:7
+msgid "Loading..."
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/new_data_api_button.html:9
+msgid "Data API Instructions"
+msgstr "Avaa rajapintaohje"
 
 #: ckanext/ytp/templates/package/snippets/package_form.html:30
 msgid "Next: Add Data"
@@ -2568,7 +2592,7 @@ msgid "eg. January 2011 Gold Prices"
 msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/resource_form.html:26
-#: ckanext/ytp/templates/scheming/organization/about.html:14
+#: ckanext/ytp/templates/scheming/organization/about.html:16
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -2881,7 +2905,7 @@ msgstr ""
 "Sallitut tiedostomuodot ovat: pdf, jpg, jpeg, png, doc, docx, xls, xlsx, "
 "ppt, pptx, odt, ods, txt."
 
-#: ckanext/ytp/templates/scheming/organization/about.html:36
+#: ckanext/ytp/templates/scheming/organization/about.html:38
 msgid "Logo of organization {org}"
 msgstr ""
 
@@ -3101,11 +3125,11 @@ msgstr "Leveys:"
 msgid "Height:"
 msgstr "Korkeus:"
 
-#: ckanext/ytp/templates/snippets/facet_list.html:87
+#: ckanext/ytp/templates/snippets/facet_list.html:96
 msgid "Show less"
 msgstr "Näytä vähemmän"
 
-#: ckanext/ytp/templates/snippets/facet_list.html:91
+#: ckanext/ytp/templates/snippets/facet_list.html:100
 msgid "There are no {facet_type} that match this search"
 msgstr "Hakutulokset eivät sisällä \"{facet_type}\"-kenttiä"
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
@@ -10,15 +10,16 @@
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2021
 # Daniel Vainio, 2021
+# Ville Teräväinen, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-10 09:54+0000\n"
+"POT-Creation-Date: 2022-07-13 10:02+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Daniel Vainio, 2021\n"
+"Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,47 +28,47 @@ msgstr ""
 "Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/ytp/auth.py:17 ckanext/ytp/auth.py:31
+#: ckanext/ytp/auth.py:18 ckanext/ytp/auth.py:32
 msgid "Only the owner can update a related item"
 msgstr "Endast ägaren kan uppdatera ett relaterat medium"
 
-#: ckanext/ytp/auth.py:36
+#: ckanext/ytp/auth.py:37
 msgid "You must be a sysadmin to change a related item's featured field."
 msgstr "Du måste vara systemadministratör för att ändra fältet"
 
-#: ckanext/ytp/auth.py:53
+#: ckanext/ytp/auth.py:54
 msgid "You must be a sysadmin to create a featured related item"
 msgstr "Du måste vara systemadministratör för att skapa denna"
 
-#: ckanext/ytp/auth.py:61 ckanext/ytp/auth.py:64
+#: ckanext/ytp/auth.py:62 ckanext/ytp/auth.py:65
 msgid "You must be logged in to add a related item"
 msgstr "Du måste vara inloggad för att lägga till en relaterad post"
 
-#: ckanext/ytp/auth.py:71 ckanext/ytp/auth.py:76
+#: ckanext/ytp/auth.py:72 ckanext/ytp/auth.py:77
 #, python-format
 msgid "User %s not authorized to create public organizations"
 msgstr "Användaren %s saknar behörighet att skapa offentliga organisationer"
 
-#: ckanext/ytp/auth.py:89
+#: ckanext/ytp/auth.py:90
 msgid "Only registered users can create organizations"
 msgstr "Endast registrerade användare kan skapa organisationer"
 
-#: ckanext/ytp/auth.py:104 ckanext/ytp/validators.py:468
+#: ckanext/ytp/auth.py:105 ckanext/ytp/validators.py:468
 #, python-format
 msgid "User %s is not administrator in the selected parent organization"
 msgstr "Användaren %s är inte huvudanvändare i den valda topporganisationen"
 
-#: ckanext/ytp/auth.py:113
+#: ckanext/ytp/auth.py:114
 #, python-format
 msgid "User %s not authorized to create organizations"
 msgstr "Användaren %s saknar behörighet att skapa organisationer"
 
-#: ckanext/ytp/auth.py:133
+#: ckanext/ytp/auth.py:136
 msgid "Cannot modify dataset because of organization policy"
 msgstr "Att redigera datamängden strider mot organisationens policy"
 
-#: ckanext/ytp/auth.py:141 ckanext/ytp/views_organization.py:219
-#: ckanext/ytp/views_organization.py:267
+#: ckanext/ytp/auth.py:144 ckanext/ytp/views_organization.py:275
+#: ckanext/ytp/views_organization.py:323
 msgid "Only system administrators are allowed to view user list."
 msgstr "Endast systemadministratören får granska användarlistan"
 
@@ -175,11 +176,11 @@ msgid "Related item was successfully updated"
 msgstr "Det relaterade objektet har uppdaterats"
 
 #: ckanext/ytp/controller.py:419 ckanext/ytp/controller.py:691
-#: ckanext/ytp/views_organization.py:76
+#: ckanext/ytp/views_organization.py:77
 msgid "Integrity Error"
 msgstr "Integritetsfel"
 
-#: ckanext/ytp/controller.py:439 ckanext/ytp/templates/package/search.html:84
+#: ckanext/ytp/controller.py:439 ckanext/ytp/templates/package/search.html:83
 #: ckanext/ytp/templates/package/snippets/related_item.html:21
 msgid "API"
 msgstr "API"
@@ -253,11 +254,11 @@ msgstr ""
 msgid "Date format incorrect"
 msgstr "Felaktigt datumformat"
 
-#: ckanext/ytp/helpers.py:98 ckanext/ytp/plugin.py:322
+#: ckanext/ytp/helpers.py:103 ckanext/ytp/plugin.py:321
 msgid "Unnamed resource"
 msgstr "Namnlös dataresurs"
 
-#: ckanext/ytp/helpers.py:578
+#: ckanext/ytp/helpers.py:583
 msgid "-"
 msgstr ""
 
@@ -324,7 +325,7 @@ msgstr "Radera användarkonto"
 msgid "Users"
 msgstr "Användare"
 
-#: ckanext/ytp/menu.py:155 ckanext/ytp/plugin.py:270
+#: ckanext/ytp/menu.py:155
 #: ckanext/ytp/templates/organization/admin_list.html:31
 #: ckanext/ytp/templates/organization/edit.html:4
 #: ckanext/ytp/templates/organization/index.html:13
@@ -356,43 +357,55 @@ msgstr "Publicera öppna data"
 msgid "Publish Data"
 msgstr "Publicera data"
 
-#: ckanext/ytp/plugin.py:266
+#: ckanext/ytp/plugin.py:265
 msgid "International Benchmarks"
 msgstr "Internationella jämförelser"
 
-#: ckanext/ytp/plugin.py:267 ckanext/ytp/plugin.py:281
+#: ckanext/ytp/plugin.py:266 ckanext/ytp/translations.py:68
+msgid "Geographical coverage"
+msgstr "Geografisk täckning"
+
+#: ckanext/ytp/plugin.py:267 ckanext/ytp/plugin.py:280
 msgid "Collection Types"
 msgstr "Typer av datamängder"
 
-#: ckanext/ytp/plugin.py:268
-msgid "Popular Tags"
-msgstr "Populära Nyckelord"
-
-#: ckanext/ytp/plugin.py:269 ckanext/ytp/plugin.py:283
-msgid "Content Types"
-msgstr "Innehållstyper"
-
-#: ckanext/ytp/plugin.py:271 ckanext/ytp/plugin.py:284
-#: ckanext/ytp/translations.py:35
-msgid "Formats"
-msgstr "Filformat"
-
-#: ckanext/ytp/plugin.py:273
-msgid "Sources"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:274
-msgid "Licenses"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:282
+#: ckanext/ytp/plugin.py:268 ckanext/ytp/plugin.py:281
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:14
 msgid "Tags"
 msgstr "Nyckelord"
 
-#: ckanext/ytp/plugin.py:322
+#: ckanext/ytp/plugin.py:269
+#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
+#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
+#: ckanext/ytp/templates/snippets/organization.html:21
+#: ckanext/ytp/translations.py:36
+msgid "Organization"
+msgstr "Producent"
+
+#: ckanext/ytp/plugin.py:270 ckanext/ytp/plugin.py:283
+#: ckanext/ytp/translations.py:35
+msgid "Formats"
+msgstr "Filformat"
+
+#: ckanext/ytp/plugin.py:271
+msgid "Licenses"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:272
+msgid "Category"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:273 ckanext/ytp/translations.py:87
+msgid "Producer type"
+msgstr "Regional täckning/Producenttyp"
+
+#: ckanext/ytp/plugin.py:282
+msgid "Content Types"
+msgstr "Innehållstyper"
+
+#: ckanext/ytp/plugin.py:321
 #: ckanext/ytp/templates/package/snippets/additional_info.html:2
-#: ckanext/ytp/templates/scheming/organization/about.html:18
+#: ckanext/ytp/templates/scheming/organization/about.html:20
 msgid "Additional Info"
 msgstr "Mer information"
 
@@ -456,7 +469,7 @@ msgstr "Extern"
 msgid "Internal"
 msgstr "Intern"
 
-#: ckanext/ytp/templates/package/resource_read.html:230
+#: ckanext/ytp/templates/package/resource_read.html:252
 #: ckanext/ytp/templates/package/snippets/additional_info.html:68
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:8
 #: ckanext/ytp/translations.py:28
@@ -487,13 +500,6 @@ msgstr "Logotyp eller illustrationsbild"
 #: ckanext/ytp/translations.py:34
 msgid "Size"
 msgstr "Filstorlek"
-
-#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
-#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
-#: ckanext/ytp/templates/snippets/organization.html:21
-#: ckanext/ytp/translations.py:36
-msgid "Organization"
-msgstr "Producent"
 
 #: ckanext/ytp/translations.py:37
 msgid "Key"
@@ -619,10 +625,6 @@ msgstr "t.ex. joe@example.com"
 msgid "Copyright notice"
 msgstr "Upphovsrättsmeddelande"
 
-#: ckanext/ytp/translations.py:68
-msgid "Geographical coverage"
-msgstr "Geografisk täckning"
-
 #: ckanext/ytp/translations.py:69
 msgid "Select the municipalities from which the dataset contains data."
 msgstr "Välj de kommuner som ingår i datamängden"
@@ -695,10 +697,6 @@ msgstr "Applikationens namn"
 #: ckanext/ytp/translations.py:86
 msgid "Categories"
 msgstr "Kategorier"
-
-#: ckanext/ytp/translations.py:87
-msgid "Producer type"
-msgstr "Regional täckning/Producenttyp"
 
 #: ckanext/ytp/translations.py:88
 msgid "Public administration organization"
@@ -1214,11 +1212,47 @@ msgstr ""
 msgid "e.g. avoindata@dvv.fi"
 msgstr "t.ex. avoindata@dvv.fi"
 
+#: ckanext/ytp/translations.py:219
+msgid ""
+"Deleted. The dataset is only visible to logged in users of the producer "
+"organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:220
+msgid ""
+"In draft state. The dataset is only visible to logged in users of the "
+"producer organization."
+msgstr ""
+
 #: ckanext/ytp/translations.py:221
+msgid ""
+"Private mode. The dataset is only visible to logged in users of the producer"
+" organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:222
+msgid ""
+"Deleted. The apiset is only visible to logged in users of the producer "
+"organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:223
+msgid ""
+"In draft state. The apiset is only visible to logged in users of the "
+"producer organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:224
+msgid ""
+"Private mode. The apiset is only visible to logged in users of the producer "
+"organization."
+msgstr ""
+
+#: ckanext/ytp/translations.py:227
 msgid "Data resource title"
 msgstr "Dataresursens namn"
 
-#: ckanext/ytp/translations.py:222
+#: ckanext/ytp/translations.py:228
 msgid ""
 "Write a short and descriptive name for the data resource. If the data covers"
 " a specific time frame, mention that in the name."
@@ -1226,15 +1260,15 @@ msgstr ""
 "Ange en kort och beskrivande namn för dataresursen. Om datan endast täcker "
 "en viss tidsintervall, uppge detta i namnet."
 
-#: ckanext/ytp/translations.py:223
+#: ckanext/ytp/translations.py:229
 msgid "e.g. Most popular Finnish first names 2019"
 msgstr "t.ex. de mest populära förnamnen i Finland 2019 "
 
-#: ckanext/ytp/translations.py:224
+#: ckanext/ytp/translations.py:230
 msgid "Resource *"
 msgstr "Dataresurs *"
 
-#: ckanext/ytp/translations.py:225
+#: ckanext/ytp/translations.py:231
 msgid ""
 "Add the data resource by uploading a file or adding a link to the "
 "data.<br>Select or drag the files here.<br>The maximum file size is 5 Gb. "
@@ -1246,15 +1280,15 @@ msgstr ""
 "Tillåtna filformat: pdf, jpg, jpeg, png, doc, docx, xls, xlsx, csv, ppt, "
 "pptx, odt, ods, txt.<br>Länk: Lägg till en länk till datan."
 
-#: ckanext/ytp/translations.py:226
+#: ckanext/ytp/translations.py:232
 msgid "Data resource description"
 msgstr "Beskrivning av dataresursen"
 
-#: ckanext/ytp/translations.py:227
+#: ckanext/ytp/translations.py:233
 msgid "Write a description for the resource"
 msgstr "Ange en beskrivning för resursen"
 
-#: ckanext/ytp/translations.py:228
+#: ckanext/ytp/translations.py:234
 msgid ""
 "Describe the data clearly and concisely. Use as confining terms as possible "
 "to make it easier to find and understand the data."
@@ -1262,15 +1296,15 @@ msgstr ""
 "En kortfattad och lättbegriplig beskrivning av applikationen. Använd så "
 "avgränsande termer som möjligt för att göra det enklare att förstå datan."
 
-#: ckanext/ytp/translations.py:229
+#: ckanext/ytp/translations.py:235
 msgid "Additional information"
 msgstr "Mer information"
 
-#: ckanext/ytp/translations.py:230
+#: ckanext/ytp/translations.py:236
 msgid "Data status"
 msgstr "Datastatus"
 
-#: ckanext/ytp/translations.py:231
+#: ckanext/ytp/translations.py:237
 msgid ""
 "Define a state for the data. This is recommended especially if your dataset "
 "has data resources from multiple years."
@@ -1278,11 +1312,11 @@ msgstr ""
 "Du kan fastställa ett status för datan. Det rekommenderas framför allt om "
 "din datamängd innehåller dataresurser från flera olika år."
 
-#: ckanext/ytp/translations.py:232
+#: ckanext/ytp/translations.py:238
 msgid "Coordinate system"
 msgstr "Koordinatsystem"
 
-#: ckanext/ytp/translations.py:233
+#: ckanext/ytp/translations.py:239
 msgid ""
 "If your data includes geographic information, specify the coordinate system "
 "it uses."
@@ -1290,11 +1324,11 @@ msgstr ""
 "Ange kartmaterialets koordinatsystem. T.ex. koordinatsystemet för "
 "positionsdata."
 
-#: ckanext/ytp/translations.py:234
+#: ckanext/ytp/translations.py:240
 msgid "e.g. WGS84 (World Geodetic System 1984)"
 msgstr "t.ex. WGS84 (World Geodetic System 1984)"
 
-#: ckanext/ytp/translations.py:235
+#: ckanext/ytp/translations.py:241
 msgid ""
 "Select the time frame by which the data is separated. For example, does the "
 "resource include data from every week or month."
@@ -1302,223 +1336,223 @@ msgstr ""
 "Ange hur noggrant datan är separerade i materialet, till exempel om "
 "materialet innehåller data från varje vecka eller månad."
 
-#: ckanext/ytp/translations.py:236
+#: ckanext/ytp/translations.py:242
 msgid "e.g. a month"
 msgstr "t.ex. en månad"
 
-#: ckanext/ytp/translations.py:237
+#: ckanext/ytp/translations.py:243
 msgid "Time Frame"
 msgstr "Tidsram"
 
-#: ckanext/ytp/translations.py:238
+#: ckanext/ytp/translations.py:244
 msgid "Start date"
 msgstr "Startdatum"
 
-#: ckanext/ytp/translations.py:239
+#: ckanext/ytp/translations.py:245
 msgid "End date"
 msgstr "Slutdatum"
 
-#: ckanext/ytp/translations.py:242
+#: ckanext/ytp/translations.py:248
 msgid "Producer name"
 msgstr ""
 
-#: ckanext/ytp/translations.py:243
+#: ckanext/ytp/translations.py:249
 msgid "Producer description"
 msgstr ""
 
-#: ckanext/ytp/translations.py:244
+#: ckanext/ytp/translations.py:250
 msgid "Common, compact and plain description about producer"
 msgstr ""
 
-#: ckanext/ytp/translations.py:245
+#: ckanext/ytp/translations.py:251
 msgid "Other information"
 msgstr ""
 
-#: ckanext/ytp/translations.py:248
+#: ckanext/ytp/translations.py:254
 msgid "cc-by"
 msgstr ""
 
-#: ckanext/ytp/translations.py:249
+#: ckanext/ytp/translations.py:255
 msgid "cc-by-4-fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:250
+#: ckanext/ytp/translations.py:256
 msgid "cc-by-4.0"
 msgstr ""
 
-#: ckanext/ytp/translations.py:251
+#: ckanext/ytp/translations.py:257
 msgid "cc-by-sa"
 msgstr ""
 
-#: ckanext/ytp/translations.py:252
+#: ckanext/ytp/translations.py:258
 msgid "cc-by-sa-1-fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:253
+#: ckanext/ytp/translations.py:259
 msgid "cc-nc"
 msgstr ""
 
-#: ckanext/ytp/translations.py:254
+#: ckanext/ytp/translations.py:260
 msgid "cc-zero"
 msgstr ""
 
-#: ckanext/ytp/translations.py:255
+#: ckanext/ytp/translations.py:261
 msgid "cc-zero-1.0"
 msgstr ""
 
-#: ckanext/ytp/translations.py:256
+#: ckanext/ytp/translations.py:262
 msgid "gfdl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:257
+#: ckanext/ytp/translations.py:263
 msgid "helsinkikanava-opendata-tos"
 msgstr ""
 
-#: ckanext/ytp/translations.py:258
+#: ckanext/ytp/translations.py:264
 msgid "hri-tietoaineistot-lisenssi-nimea"
 msgstr ""
 
-#: ckanext/ytp/translations.py:259
+#: ckanext/ytp/translations.py:265
 msgid "ilmoitettumuualla"
 msgstr ""
 
-#: ckanext/ytp/translations.py:260
+#: ckanext/ytp/translations.py:266
 msgid "kmo-aluejakorajat"
 msgstr ""
 
-#: ckanext/ytp/translations.py:261
+#: ckanext/ytp/translations.py:267
 msgid "notspecified"
 msgstr ""
 
-#: ckanext/ytp/translations.py:262
+#: ckanext/ytp/translations.py:268
 msgid "odc-by"
 msgstr ""
 
-#: ckanext/ytp/translations.py:263
+#: ckanext/ytp/translations.py:269
 msgid "odc-odbl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:264
+#: ckanext/ytp/translations.py:270
 msgid "odc-pddl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:265
+#: ckanext/ytp/translations.py:271
 msgid "other"
 msgstr ""
 
-#: ckanext/ytp/translations.py:266
+#: ckanext/ytp/translations.py:272
 msgid "other-at"
 msgstr ""
 
-#: ckanext/ytp/translations.py:267
+#: ckanext/ytp/translations.py:273
 msgid "other-closed"
 msgstr ""
 
-#: ckanext/ytp/translations.py:268
+#: ckanext/ytp/translations.py:274
 msgid "other-nc"
 msgstr ""
 
-#: ckanext/ytp/translations.py:269
+#: ckanext/ytp/translations.py:275
 msgid "other-open"
 msgstr ""
 
-#: ckanext/ytp/translations.py:270
+#: ckanext/ytp/translations.py:276
 msgid "other-pd"
 msgstr ""
 
-#: ckanext/ytp/translations.py:271
+#: ckanext/ytp/translations.py:277
 msgid "uk-ogl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:274
+#: ckanext/ytp/translations.py:280
 msgid "Platforms"
 msgstr ""
 
-#: ckanext/ytp/translations.py:277
+#: ckanext/ytp/translations.py:283
 msgid "Show more collection_type"
 msgstr "Vias flera Datamängder"
 
-#: ckanext/ytp/translations.py:278
+#: ckanext/ytp/translations.py:284
 msgid "Show more vocab_international_benchmarks"
 msgstr "Visa flera Internationella Jämförelser"
 
-#: ckanext/ytp/translations.py:279
+#: ckanext/ytp/translations.py:285
 msgid "Show more vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:280
+#: ckanext/ytp/translations.py:286
 msgid "Show more vocab_keywords_fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:281
+#: ckanext/ytp/translations.py:287
 msgid "Show more vocab_keywords_sv"
 msgstr "Visa flera Nyckelord"
 
-#: ckanext/ytp/translations.py:282
+#: ckanext/ytp/translations.py:288
 msgid "Show more organization"
 msgstr "Visa flera Producenter"
 
-#: ckanext/ytp/translations.py:283
+#: ckanext/ytp/translations.py:289
 msgid "Show more res_format"
 msgstr "Visa flera Format"
 
-#: ckanext/ytp/translations.py:284
+#: ckanext/ytp/translations.py:290
 msgid "Show more source"
 msgstr "Visa flera Källor"
 
-#: ckanext/ytp/translations.py:285
+#: ckanext/ytp/translations.py:291
 msgid "Show more license_id"
 msgstr "Visa flera Licenser"
 
-#: ckanext/ytp/translations.py:286
+#: ckanext/ytp/translations.py:292
 msgid "Show more groups"
 msgstr "Visa flera Grupper"
 
-#: ckanext/ytp/translations.py:287
+#: ckanext/ytp/translations.py:293
 msgid "Show more vocab_platform"
 msgstr "Visa flera Plattformar"
 
-#: ckanext/ytp/translations.py:290
+#: ckanext/ytp/translations.py:296
 msgid "Show less collection_type"
 msgstr "Vias färre Datamängder"
 
-#: ckanext/ytp/translations.py:291
+#: ckanext/ytp/translations.py:297
 msgid "Show less vocab_international_benchmarks"
 msgstr "Visa färre Internationella Jämförelser"
 
-#: ckanext/ytp/translations.py:292
+#: ckanext/ytp/translations.py:298
 msgid "Show less vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:293
+#: ckanext/ytp/translations.py:299
 msgid "Show less vocab_keywords_fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:294
+#: ckanext/ytp/translations.py:300
 msgid "Show less vocab_keywords_sv"
 msgstr "Visa färre Nyckelord"
 
-#: ckanext/ytp/translations.py:295
+#: ckanext/ytp/translations.py:301
 msgid "Show less organization"
 msgstr "Visa färre Producenter"
 
-#: ckanext/ytp/translations.py:296
+#: ckanext/ytp/translations.py:302
 msgid "Show less res_format"
 msgstr "Visa färre Format"
 
-#: ckanext/ytp/translations.py:297
+#: ckanext/ytp/translations.py:303
 msgid "Show less source"
 msgstr "Visa färre Källor"
 
-#: ckanext/ytp/translations.py:298
+#: ckanext/ytp/translations.py:304
 msgid "Show less license_id"
 msgstr "Visa färre Licenser"
 
-#: ckanext/ytp/translations.py:299
+#: ckanext/ytp/translations.py:305
 msgid "Show less groups"
 msgstr "Visa färre Grupper"
 
-#: ckanext/ytp/translations.py:300
+#: ckanext/ytp/translations.py:306
 msgid "Show less vocab_platform"
 msgstr "Visa färre Plattformar"
 
@@ -1574,21 +1608,22 @@ msgstr "Slutdatumet infaller före startdatumet"
 msgid "Only sysadmin can change feature: %s"
 msgstr "Endast systemadministratörer får ändra funktionen: %s"
 
-#: ckanext/ytp/views_organization.py:53
+#: ckanext/ytp/views_organization.py:54
 msgid "Unauthorized to create a group"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:74 ckanext/ytp/views_organization.py:114
-#: ckanext/ytp/views_organization.py:161 ckanext/ytp/views_organization.py:342
+#: ckanext/ytp/views_organization.py:75 ckanext/ytp/views_organization.py:104
+#: ckanext/ytp/views_organization.py:170 ckanext/ytp/views_organization.py:217
+#: ckanext/ytp/views_organization.py:398
 msgid "Group not found"
 msgstr "Hittar inte gruppen"
 
-#: ckanext/ytp/views_organization.py:164
+#: ckanext/ytp/views_organization.py:220
 #, python-format
 msgid "User %r not authorized to edit members of %s"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:288
+#: ckanext/ytp/views_organization.py:344
 msgid "Not authorized to see this page"
 msgstr "Behörighet krävs för att visa sidan"
 
@@ -1629,7 +1664,7 @@ msgstr "Avbryt"
 msgid "Remove"
 msgstr "Ta bort"
 
-#: ckanext/ytp/resources/opendata/scripts/slug-preview-ex.js:53
+#: ckanext/ytp/resources/opendata/scripts/slug-preview-ex.js:59
 #: ckanext/ytp/templates/organization/admin_list.html:50
 #: ckanext/ytp/templates/organization/bulk_process.html:47
 #: ckanext/ytp/templates/organization/members.html:35
@@ -1696,6 +1731,11 @@ msgstr ""
 msgid "Hide search filters"
 msgstr "Dölj filtren"
 
+#: ckanext/ytp/templates/apiset/read.html:28
+#: ckanext/ytp/templates/apiset/resource_read.html:75
+msgid "Interfaces"
+msgstr ""
+
 #: ckanext/ytp/templates/apiset/resource_read.html:17
 msgid "Interface manual"
 msgstr ""
@@ -1704,30 +1744,26 @@ msgstr ""
 msgid "Additional Information"
 msgstr ""
 
-#: ckanext/ytp/templates/apiset/resource_read.html:75
-msgid "Interfaces"
-msgstr ""
-
 #: ckanext/ytp/templates/apiset/resource_read.html:105
 #: ckanext/ytp/templates/organization/read_base.html:37
-#: ckanext/ytp/templates/package/resource_read.html:64
+#: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:9
 #: ckanext/ytp/templates/package/snippets/resource_item3.html:9
 msgid "Manage"
 msgstr "Redigera"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:111
-#: ckanext/ytp/templates/package/resource_read.html:70
+#: ckanext/ytp/templates/package/resource_read.html:72
 msgid "View"
 msgstr "Granska"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:113
-#: ckanext/ytp/templates/package/resource_read.html:72
+#: ckanext/ytp/templates/package/resource_read.html:74
 msgid "API Endpoint"
 msgstr "API-slutpunkt"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:115
-#: ckanext/ytp/templates/package/resource_read.html:74
+#: ckanext/ytp/templates/package/resource_read.html:76
 #: ckanext/ytp/templates/package/snippets/related_item.html:65
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:13
 #: ckanext/ytp/templates/package/snippets/resource_item3.html:11
@@ -1735,19 +1771,19 @@ msgid "Open"
 msgstr "Öppna"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:117
-#: ckanext/ytp/templates/package/resource_read.html:76
+#: ckanext/ytp/templates/package/resource_read.html:78
 #: ckanext/ytp/templates/package/snippets/resource_item.html:51
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:15
 msgid "Download"
 msgstr "Ladda ned"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:139
-#: ckanext/ytp/templates/package/resource_read.html:109
+#: ckanext/ytp/templates/package/resource_read.html:113
 msgid "From the dataset abstract"
 msgstr "Av datasmängdens sammandrag"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:141
-#: ckanext/ytp/templates/package/resource_read.html:111
+#: ckanext/ytp/templates/package/resource_read.html:115
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr "Källa: <a href=\"%(url)s\">%(dataset)s</a>"
@@ -1956,7 +1992,7 @@ msgid "No organizations found"
 msgstr "Inga producenter hittades"
 
 #: ckanext/ytp/templates/organization/index.html:91
-#: ckanext/ytp/templates/package/search.html:104
+#: ckanext/ytp/templates/package/search.html:103
 msgid "Filter list"
 msgstr "Filtrera listan"
 
@@ -2001,6 +2037,10 @@ msgstr "Medlemmar"
 msgid "Membership Requests"
 msgstr "Medlemsansökningar"
 
+#: ckanext/ytp/templates/organization/new.html:6
+msgid "Create an Organization"
+msgstr ""
+
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
@@ -2018,7 +2058,7 @@ msgid "Last Modified"
 msgstr "Senast redigerat"
 
 #: ckanext/ytp/templates/organization/read.html:19
-#: ckanext/ytp/templates/package/search.html:63
+#: ckanext/ytp/templates/package/search.html:62
 #: ckanext/ytp/templates/snippets/package_item.html:45
 #: ckanext/ytp/templates/snippets/popular.html:3
 msgid "Popular"
@@ -2161,107 +2201,107 @@ msgstr "DataStore"
 msgid "Views"
 msgstr "Vyer"
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 #, python-format
 msgid "<a href=\"%(url)s\">"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 msgid "dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:89
+#: ckanext/ytp/templates/package/resource_read.html:93
 #, python-format
 msgid "%(dataset)s"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:135
+#: ckanext/ytp/templates/package/resource_read.html:157
 #: ckanext/ytp/templates/package/snippets/resource_item.html:40
 #: ckanext/ytp/templates/snippets/datapreview_embed_dialog.html:18
 msgid "Preview"
 msgstr "Förhandsgranskning"
 
-#: ckanext/ytp/templates/package/resource_read.html:155
+#: ckanext/ytp/templates/package/resource_read.html:177
 msgid "There are no views created for this resource yet."
 msgstr "Inga förhandsgranskningar har skapats för denna dataresurs."
 
-#: ckanext/ytp/templates/package/resource_read.html:159
+#: ckanext/ytp/templates/package/resource_read.html:181
 msgid "Not seeing the views you were expecting?"
 msgstr "Ser du inte de vyer du förväntat dig?"
 
-#: ckanext/ytp/templates/package/resource_read.html:161
+#: ckanext/ytp/templates/package/resource_read.html:183
 #: ckanext/ytp/templates/package/snippets/resource_view.html:26
 msgid "Click here for more information."
 msgstr "Klicka här för mer information"
 
-#: ckanext/ytp/templates/package/resource_read.html:164
+#: ckanext/ytp/templates/package/resource_read.html:186
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr "Möjliga anledningar till att vyer saknas:"
 
-#: ckanext/ytp/templates/package/resource_read.html:166
+#: ckanext/ytp/templates/package/resource_read.html:188
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:167
+#: ckanext/ytp/templates/package/resource_read.html:189
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/resource_read.html:190
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, "
 "or the data may not have been pushed to the DataStore, or the DataStore "
 "hasn't finished processing the data yet"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:184
+#: ckanext/ytp/templates/package/resource_read.html:206
 msgid "Extra information"
 msgstr "Ytterligare information"
 
-#: ckanext/ytp/templates/package/resource_read.html:188
+#: ckanext/ytp/templates/package/resource_read.html:210
 #: ckanext/ytp/templates/package/snippets/resource_form.html:31
 msgid "Format"
 msgstr "Format"
 
-#: ckanext/ytp/templates/package/resource_read.html:189
-#: ckanext/ytp/templates/package/resource_read.html:227
-#: ckanext/ytp/templates/package/resource_read.html:231
-#: ckanext/ytp/templates/package/resource_read.html:235
+#: ckanext/ytp/templates/package/resource_read.html:211
+#: ckanext/ytp/templates/package/resource_read.html:249
+#: ckanext/ytp/templates/package/resource_read.html:253
+#: ckanext/ytp/templates/package/resource_read.html:257
 msgid "unknown"
 msgstr "okänd"
 
-#: ckanext/ytp/templates/package/resource_read.html:220
+#: ckanext/ytp/templates/package/resource_read.html:242
 msgid "Temporal Coverage"
 msgstr "Tidsmässig täckning"
 
-#: ckanext/ytp/templates/package/resource_read.html:226
+#: ckanext/ytp/templates/package/resource_read.html:248
 msgid "Last updated"
 msgstr "Senaste uppdatering"
 
-#: ckanext/ytp/templates/package/resource_read.html:234
+#: ckanext/ytp/templates/package/resource_read.html:256
 msgid "sha256"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:264
+#: ckanext/ytp/templates/package/resource_read.html:286
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:111
 msgid "Stats"
 msgstr "Rapporter"
 
-#: ckanext/ytp/templates/package/resource_read.html:265
+#: ckanext/ytp/templates/package/resource_read.html:287
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:112
 msgid "Last 30 days, updated daily"
 msgstr "Senaste 30 dagarna, uppdateras dagligen"
 
-#: ckanext/ytp/templates/package/resource_read.html:268
+#: ckanext/ytp/templates/package/resource_read.html:290
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:119
 msgid "All time downloads:"
 msgstr "Nedladdningar totalt:"
 
-#: ckanext/ytp/templates/package/resource_read.html:278
+#: ckanext/ytp/templates/package/resource_read.html:300
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:127
 msgid "Year"
 msgstr "År"
 
-#: ckanext/ytp/templates/package/resource_read.html:278
+#: ckanext/ytp/templates/package/resource_read.html:300
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:127
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:11
 msgid "Downloads"
@@ -2304,32 +2344,31 @@ msgstr "Stigande efter datumet för skapande"
 msgid "Date Created Descending"
 msgstr "Fallande efter datumet för skapande"
 
-#: ckanext/ytp/templates/package/search.html:62
-#: ckanext/ytp/templates/package/snippets/additional_info.html:12
-msgid "Source"
-msgstr "Källa"
-
-#: ckanext/ytp/templates/package/search.html:85
+#: ckanext/ytp/templates/package/search.html:84
 msgid "API Docs"
 msgstr "API dokumentation"
 
-#: ckanext/ytp/templates/package/search.html:87
+#: ckanext/ytp/templates/package/search.html:86
 msgid "full {format} dump"
 msgstr "full {format} dump"
 
-#: ckanext/ytp/templates/package/search.html:88
+#: ckanext/ytp/templates/package/search.html:87
 #, python-format
 msgid ""
 "You can also access this registry using the %(api_link)s (see "
 "%(api_doc_link)s) or download a %(dump_link)s."
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:92
+#: ckanext/ytp/templates/package/search.html:91
 #, python-format
 msgid ""
 "You can also access this registry using the %(api_link)s (see "
 "%(api_doc_link)s)."
 msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/additional_info.html:12
+msgid "Source"
+msgstr "Källa"
 
 #: ckanext/ytp/templates/package/snippets/additional_info.html:23
 #: ckanext/ytp/templates/package/snippets/additional_info.html:28
@@ -2361,7 +2400,7 @@ msgid "Show more categories"
 msgstr "Visa flera Kategorier"
 
 #: ckanext/ytp/templates/package/snippets/categories.html:34
-#: ckanext/ytp/templates/snippets/facet_list.html:84
+#: ckanext/ytp/templates/snippets/facet_list.html:93
 msgid "Show more"
 msgstr "Visa flera"
 
@@ -2407,31 +2446,6 @@ msgstr "Applikationer"
 msgid "Social"
 msgstr "Dela i sociala medier"
 
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:5
-msgid ""
-"Deleted. The dataset is only visible to logged in users of the producer "
-"organization."
-msgstr ""
-
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:8
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:18
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:28
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:34
-msgid "Edit dataset"
-msgstr ""
-
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:15
-msgid ""
-"In draft state. The dataset is only visible to logged in users of the "
-"producer organization."
-msgstr ""
-
-#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:25
-msgid ""
-"Private mode. The dataset is only visible to logged in users of the producer"
-" organization."
-msgstr ""
-
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:17
 #, python-format
 msgid ""
@@ -2458,6 +2472,14 @@ msgstr ""
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:43
 msgid "https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/new_data_api_button.html:7
+msgid "Loading..."
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/new_data_api_button.html:9
+msgid "Data API Instructions"
+msgstr "Öppna gränssnittshjälpen"
 
 #: ckanext/ytp/templates/package/snippets/package_form.html:30
 msgid "Next: Add Data"
@@ -2534,7 +2556,7 @@ msgid "eg. January 2011 Gold Prices"
 msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/resource_form.html:26
-#: ckanext/ytp/templates/scheming/organization/about.html:14
+#: ckanext/ytp/templates/scheming/organization/about.html:16
 msgid "Description"
 msgstr "Beskrivning"
 
@@ -2832,7 +2854,7 @@ msgid ""
 " odt, ods, txt."
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/organization/about.html:36
+#: ckanext/ytp/templates/scheming/organization/about.html:38
 msgid "Logo of organization {org}"
 msgstr ""
 
@@ -3048,11 +3070,11 @@ msgstr "Bredd:"
 msgid "Height:"
 msgstr "Höjd:"
 
-#: ckanext/ytp/templates/snippets/facet_list.html:87
+#: ckanext/ytp/templates/snippets/facet_list.html:96
 msgid "Show less"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/facet_list.html:91
+#: ckanext/ytp/templates/snippets/facet_list.html:100
 msgid "There are no {facet_type} that match this search"
 msgstr "Sökresultaten innehåller inga fält med {facet_type}"
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/resource_read.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/resource_read.html
@@ -13,6 +13,8 @@
 {% endblock -%}
 
 
+
+
 {% block subtitle %}{{ h.dataset_display_name(c.package) }} - {{ h.resource_display_name(res) }}{% endblock %}
 
   {% block toolbar %}
@@ -78,9 +80,6 @@
                           </a>
                         </li>
                       {% endif %}
-                      {% if 'datastore' in g.plugins %}
-                        <li>{% snippet 'package/snippets/data_api_button.html', resource=res, datastore_root_url=c.datastore_api %}</li>
-                      {% endif %}
                     {% endblock %}
                   </ul>
                 {% endblock %}
@@ -90,7 +89,7 @@
               </div>
             </div>
             
-            <div class="row justify-content-center pb-1">
+            <div class="row justify-content-center pb-3">
               {% block resource_content %}
               <div class="col-md-12">
                 {% block resource_read_title %}
@@ -114,6 +113,14 @@
               </div>
             {% endblock %}
             </div>
+
+          <div class="row justify-content-center">
+            <div class="col md-12 p-2">
+              {% if 'datastore' in g.plugins %}
+                {% snippet 'package/snippets/new_data_api_button.html', resource=res, datastore_root_url=c.datastore_api %}
+              {% endif %}
+            </div>
+          </div>
 
           <div class="row justify-content-center pb-3">
             {% block data_preview %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/new_data_api_button.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/new_data_api_button.html
@@ -1,0 +1,10 @@
+{# Data API Help Button
+  custom implementation of teh data_api_button.html
+   resource: the resource
+    #}
+
+    {% if resource.datastore_active %}
+      {% set loading_text = _('Loading...') %}
+      {% set api_info_url = h.url_for(controller='api', action='snippet', ver=1, snippet_path='api_info.html', resource_id=resource.id) %}
+      <a class="btn btn-menu-manage resource-url-analytics" href="{{ api_info_url }}" data-module="api-info" data-module-template="{{ api_info_url }}" data-loading-text="{{ loading_text }}">{{ _('Data API Instructions') }}</a>
+      {% endif %}


### PR DESCRIPTION
Fixed the text for dataset api instructions. Also changed the layout for it to match more to the one used in the design. Note that the page layout is a bit different from the actual design.
![image](https://user-images.githubusercontent.com/24498487/178735917-d5aa08fb-9963-45dd-a7ad-f64402ac2c7e.png)
