### PR TITLE
fix(AV-1771): Lowercase the organization search keywords

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -775,7 +775,7 @@ def action_organization_tree_list(context, data_dict):
     # Filter based on search query if provided
     if q:
         result_titles_and_gids = ((title, gid) for title, gid in translated_titles_and_gids
-                                  if q in title)
+                                  if q.lower() in title)
     else:
         result_titles_and_gids = translated_titles_and_gids
 


### PR DESCRIPTION
Organization titles were already lowercased but the search keywords were not. As such keywords with uppercase letters would fail to find results.

Fixed by lowercasing the search keywords as well.