### PR TITLE
fix(AV-1545): Only include active packages in package_count 

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -805,6 +805,7 @@ def action_organization_tree_list(context, data_dict):
                                               model.GroupExtra.state == 'active'))
             .outerjoin(model.Package, and_(model.Package.type == 'dataset',
                                            model.Package.private == false(),
+                                           model.Package.state == 'active',
                                            or_(model.Package.owner_org == model.Group.name,
                                                model.Package.owner_org == model.Group.id)))
             .outerjoin(parent_member, and_(parent_member.group_id == model.Group.id,


### PR DESCRIPTION
Previous query included also packages in states draft and deleted 