### PR TITLE
fix(AV-1773): Ensure variable is dict before trying to .get()

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -456,7 +456,6 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
 
         # Populate update frequencies for apisets from validated data_dict
         validated_data_dict = pkg_dict.get('validated_data_dict')
-        log.info(json.dumps(pkg_dict))
         converted_validated_data_dict = json.loads(validated_data_dict)
         resources = converted_validated_data_dict.get('resources')
         if resources:

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -456,6 +456,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
 
         # Populate update frequencies for apisets from validated data_dict
         validated_data_dict = pkg_dict.get('validated_data_dict')
+        log.info(json.dumps(pkg_dict))
         converted_validated_data_dict = json.loads(validated_data_dict)
         resources = converted_validated_data_dict.get('resources')
         if resources:
@@ -475,7 +476,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
             prop_value = json.loads(prop_json)
             # Add for each language
             for lang in languages:
-                if prop_value.get(lang):
+                if type(prop_value) is dict and prop_value.get(lang):
                     prop_value[lang] = [tag for tag in {tag.lower() for tag in prop_value[lang]} if tag not in ignored_tags]
                     pkg_dict['vocab_%s_%s' % (prop_key, lang)] = [tag for tag in prop_value[lang]]
             pkg_dict[prop_key] = json.dumps(prop_value)


### PR DESCRIPTION
https://github.com/vrk-kpa/opendata-ckan/blob/master/modules/ckanext-ytp_main/ckanext/ytp/plugin.py#L462

Bad old data causes issues starting from the above code. In some cases resources update_frequency (after json loads) can include "{}" as a string which is then dumped to form '"{}"' which is parsed into string again which trips the .get() a bit further down the line.

2022-08-03 12:35:03,384 INFO  [ckanext.ytp.plugin] freq
'{}'
2022-08-03 12:35:03,384 INFO  [ckanext.ytp.plugin] <class 'str'>
'"{}"'